### PR TITLE
fix NSetSCU works for N-SET-RQ, tidy up upsscp/handlers for N-SET-RSP

### DIFF
--- a/tdwii_plus_examples/nsetscu.py
+++ b/tdwii_plus_examples/nsetscu.py
@@ -2,6 +2,7 @@
 import logging
 
 from pydicom import Dataset
+from pydicom.uid import ImplicitVRLittleEndian
 
 # from pydicom.errors import InvalidDicomError
 # from pydicom.uid import UID
@@ -9,6 +10,39 @@ from pynetdicom import AE  # , Association, UnifiedProcedurePresentationContexts
 from pynetdicom.presentation import build_context
 
 from tdwii_plus_examples import tdwii_config
+
+
+def _create_code_seq_item(value: str | int, designator: str, meaning: str) -> Dataset:
+    code_seq_item = Dataset()
+    code_seq_item.CodeValue = value
+    code_seq_item.CodingSchemeDesignator = designator
+    code_seq_item.CodeMeaning = meaning
+    return code_seq_item
+
+
+def _treatment_delivery_in_progress(beam_number: int, percent_complete: int) -> Dataset:
+    update_ds = Dataset()
+    update_ds.ProcedureStepProgressInformationSequence = Sequence()
+    info_seq_item = Dataset()
+    update_ds.ProcedureStepProgressInformationSequence.append(info_seq_item)
+    info_seq_item.ProcedureStepProgress = float(percent_complete)
+    UPSPerformedProcedureSequence = Sequence()
+    performed_processing_parameters_sequence_item = Dataset()
+    update_ds.PerformedProcessingParametersSequence = Sequence()
+    concept_name_code_sequence_item = _create_code_seq_item(
+        value="201804", designator="99IHERO2018", meaning="Referenced Beam Number"
+    )
+    performed_processing_parameters_sequence_item.ValueType = "NUM"
+    performed_processing_parameters_sequence_item.NumericValue = str(beam_number)
+    performed_processing_parameters_sequence_item.ConceptNameCodeSequence = Sequence()
+    performed_processing_parameters_sequence_item.ConceptNameCodeSequence.append(concept_name_code_sequence_item)
+    update_ds.PerformedProcessingParametersSequence.append(performed_processing_parameters_sequence_item)
+    update_ds.UnifiedProcedureStepPerformedProcedureSequence = UPSPerformedProcedureSequence
+    perf_pro_seq_item = Dataset()
+    perf_pro_seq_item.OutputInformationSequence = Sequence()
+    update_ds.UnifiedProcedureStepPerformedProcedureSequence.append(perf_pro_seq_item)
+
+    return update_ds
 
 
 class NSetSCU:
@@ -53,9 +87,12 @@ class NSetSCU:
         success = False
         if assoc.is_established:
             msg_id = 0
-            success = True
+            success = False
             ups_responses = list()
             msg_id += 1
+            n_set_ds.ensure_file_meta()
+            n_set_ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
+
             responses = assoc.send_n_set(
                 n_set_ds,
                 n_set_ds.AffectedSOPClassUID,
@@ -63,12 +100,14 @@ class NSetSCU:
                 msg_id=msg_id,
                 meta_uid=n_set_ds.AffectedSOPClassUID,
             )
-            for status, response_content in responses:
+            for status in responses:
                 if status and status.Status in [0xFF00, 0xFF01]:
-                    ups_responses.append(response_content)
+                    success = True
+                elif status is None or status == 0x0000 and success == True:
+                    continue
                 elif status is None or status.Status != 0x0000:
                     success = False
-                    error_msg = "No response at all from {dest_ae_title} to N-SET-RQ"
+                    error_msg = f"No response at all from {dest_ae_title} to N-SET-RQ"
                     if status is not None:
                         error_msg = f"Failed with status {status.Status} \
                             when trying to issue n-set for {n_set_ds.AffectedSOPInstanceUID} \
@@ -90,17 +129,6 @@ if __name__ == "__main__":
     ds.TransactionUID = "1.2.3.4.5.6.7.8.9"
     ds.RequestedSOPClassUID = UnifiedProcedureStepPush
     ds.RequestedSOPInstanceUID = "1.2.826.0.1.3680043.8.498.99261692600362543248321113263925080531"
-    update_ds = Dataset()
-    update_ds.ProcedureStepProgressInformationSequence = Sequence()
-    info_seq_item = Dataset()
-    update_ds.ProcedureStepProgressInformationSequence.append(info_seq_item)
-    info_seq_item.ProcedureStepProgress = 1.0
-    UPSPerformedProcedureSequence = Sequence()
-    # update_ds[(0x0074,0x1216)] = Sequence()
-    update_ds.UnifiedProcedureStepPerformedProcedureSequence = UPSPerformedProcedureSequence
-    output_info_seq = Sequence()
-    perf_pro_seq_item = Dataset()
-    update_ds.UnifiedProcedureStepPerformedProcedureSequence.append(perf_pro_seq_item)
-    perf_pro_seq_item.OutputInformationSequence = Sequence()
+    update_ds = _treatment_delivery_in_progress(beam_number=1, percent_complete=1)
     ds.update(update_ds)
     scu.n_set_ups(ds)

--- a/tdwii_plus_examples/nsetscu.py
+++ b/tdwii_plus_examples/nsetscu.py
@@ -103,7 +103,7 @@ class NSetSCU:
             for status in responses:
                 if status and status.Status in [0xFF00, 0xFF01]:
                     success = True
-                elif status is None or status == 0x0000 and success == True:
+                elif status is None or status == 0x0000 and success:
                     continue
                 elif status is None or status.Status != 0x0000:
                     success = False

--- a/tdwii_plus_examples/upsscp.py
+++ b/tdwii_plus_examples/upsscp.py
@@ -40,7 +40,7 @@ def _dont_log(event):
     pass
 
 
-_handlers._send_c_find_rsp = _dont_log
+# _handlers._send_c_find_rsp = _dont_log
 _handlers._send_c_get_rsp = _dont_log
 _handlers._send_c_move_rsp = _dont_log
 _handlers._send_c_store_rq = _dont_log


### PR DESCRIPTION
getting model from RequestedSOPClassUID in nset handler
only looking for status in response in nsetscu
refactored nsetscu example for future use in a TDD (created a convenience function to populate values needed in :
 **Treatment Delivery in Progress [RO-60]**

commented out the "don't log" for UPS C-FIND-RSP in _upsscp_

This addresses #62  (the information is coming from Requested SOP Class UID)
I think this completes #61 