### PR TITLE
Update python-app.yml

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
         poetry config virtualenvs.in-project true
 
     - name: Poetry Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: poetry-cache
       with:
         path: .venv


### PR DESCRIPTION
cache v2 is obsolete, updated to cache v4

## Summary by Sourcery

CI:
- Updates the GitHub Actions workflow to use cache version 4.