### PR TITLE
switching to ruff

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Lint with ruff
       run: |
-        poetry run ruff check
+        poetry run ruff check --exclude="*/ui_*.py"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,16 +53,10 @@ jobs:
       run: |
         poetry install -E all
 
-    - name: Lint with flake8
+    - name: Ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 tdwii_plus_examples --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # --extend-ignore=203 because black puts in a space before a slicing :
-        # while flake8 complains (this warning is not PEP 8 compliant), If W503 pops up, that should be disabled also
-        # poetry run flake8 tdwii_plus_examples --count --exit-zero --extend-ignore=E203 --max-line-length=127 --statistics
-        # poetry run flake8 tdwii_plus_examples --count --exit-zero --max-complexity=10 --statistics
-        poetry run flake8 --count --extend-ignore=E203 --max-line-length=127 --statistics --exclude="tdwii_plus_examples/tdd/ui_tdd.py tdwii_plus_examples/rtbdi_creator/ui_form.py tdwii_plus_examples/TDWII_PPVS_subscriber/ui_tdwii_ppvs_subscriber.py" tdwii_plus_examples
+        poetry run ruff
+
     - name: Test with pytest
       run: |
         poetry run pytest tdwii_plus_examples/tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,9 +53,9 @@ jobs:
       run: |
         poetry install -E all
 
-    - name: Ruff
+    - name: Lint with ruff
       run: |
-        poetry run ruff
+        ruff check
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Lint with ruff
       run: |
-        ruff check
+        poetry run ruff check
 
     - name: Test with pytest
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,48 +21,17 @@ repos:
     hooks:
       - id: nbstripout
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0  # Specify the latest Ruff version
     hooks:
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
+      - id: ruff
         types: [python]
-        args: ["--profile", "black"]
-
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        args: ["-l", "127"]
-
-      - id: flake8-strict
-        name: flake8 (strict)
-        entry: flake8
-        language: system
-        types: [python]
-        args: [
-          "--count",
-          "--select=E9,F63,F7,F82",
-          "--show-source",
-          "--statistics",
-        ]
-        files: ^tdwii_plus_examples/.*\.py$
-
-      - id: flake8-relaxed
-        name: flake8 (relaxed)
-        entry: flake8
-        language: system
-        types: [python]
-        args: [
-          "--count",
-          "--extend-ignore=E203",
-          "--max-line-length=127",
-          "--statistics",
-        ]
+        args: [--fix, --exit-non-zero-on-fix, --line-length=127]
         files: ^tdwii_plus_examples/.*\.py$
         exclude: ^tdwii_plus_examples/(tdd/ui_tdd\.py|rtbdi_creator/ui_form\.py|TDWII_PPVS_subscriber/ui_tdwii_ppvs_subscriber\.py)$
+
+      - id: ruff-format
+        types: [python]
 
   # Keep this as a repo hook since it's specific to the pre-commit framework
   - repo: https://github.com/floatingpurr/sync_with_poetry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,15 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.0  # Specify the latest Ruff version
     hooks:
-      - id: ruff
-        types: [python]
-        args: [--fix, --exit-non-zero-on-fix, --line-length=127]
-        files: ^tdwii_plus_examples/.*\.py$
-        exclude: ^tdwii_plus_examples/(tdd/ui_tdd\.py|rtbdi_creator/ui_form\.py|TDWII_PPVS_subscriber/ui_tdwii_ppvs_subscriber\.py)$
-
-      - id: ruff-format
-        types: [python]
+    - id: ruff
+      types: [python]
+      args: [--fix, --exit-non-zero-on-fix, --line-length=127]
+      files: ^tdwii_plus_examples/.*\.py$
+      exclude: ^tdwii_plus_examples/.*/ui_.*\.py$
+    - id: ruff-format
+      types: [python]
+      files: ^tdwii_plus_examples/.*\.py$
+      exclude: ^tdwii_plus_examples/.*/ui_.*\.py$
 
   # Keep this as a repo hook since it's specific to the pre-commit framework
   - repo: https://github.com/floatingpurr/sync_with_poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -894,6 +894,34 @@ doc = ["pytoolconfig[doc]", "sphinx (>=4.5.0)", "sphinx-autodoc-typehints (>=1.1
 release = ["pip-tools (>=6.12.1)", "toml (>=0.10.2)", "twine (>=4.0.2)"]
 
 [[package]]
+name = "ruff"
+version = "0.11.0"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "dev"]
+files = [
+    {file = "ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb"},
+    {file = "ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639"},
+    {file = "ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6"},
+    {file = "ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2"},
+    {file = "ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21"},
+    {file = "ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657"},
+    {file = "ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2"},
+]
+
+[[package]]
 name = "setuptools"
 version = "76.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1186,11 +1214,11 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [extras]
-all = ["black", "dill", "doc8", "flake8", "mypy", "pre-commit", "pylint", "pytest", "pytest-rerunfailures", "pytest-sugar", "rope", "toml", "tomlkit"]
-dev = ["black", "dill", "doc8", "flake8", "mypy", "pre-commit", "rope", "toml"]
-tests = ["dill", "flake8", "pylint", "pytest", "pytest-rerunfailures", "pytest-sugar", "toml"]
+all = ["black", "dill", "doc8", "flake8", "mypy", "pre-commit", "pylint", "pytest", "pytest-rerunfailures", "pytest-sugar", "rope", "ruff", "toml", "tomlkit"]
+dev = ["black", "dill", "doc8", "flake8", "mypy", "pre-commit", "rope", "ruff", "toml"]
+tests = ["dill", "flake8", "pylint", "pytest", "pytest-rerunfailures", "pytest-sugar", "ruff", "toml"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "e4a9cc8c10ff0d529c466d609845d1b0ad86b3bdc6fa3d92498e00d7d748084d"
+content-hash = "51323e89a37aa73a7ce0e15d4f1937731b066d930baddf63aa6940dd34d80206"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ pytest = "^8.3.4"
 pre-commit = "^4.1.0"
 ruff = "^0.11.0"
 
+[tool.ruff]
+extend-flake8-codes = true  # until I can go and change some # noqa statements
+
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ doc8 = { version = "*", optional = true }            # groups = ["dev", "all"]
 update = "^0.0.1"
 parameterized = "^0.9.0"
 isort = { version = "*", optional = true}            # groups = ["dev", "tests", "all"]
+ruff = { version = "*", optional = true}             # groups = ["dev", "tests", "all"]
 
 
 
@@ -58,6 +59,7 @@ tests = [
     "toml",
     "flake8",
     "dill",
+    "ruff"
 ]
 
 dev = [
@@ -69,6 +71,7 @@ dev = [
     "toml",
     "flake8",
     "dill",
+    "ruff",
 ]
 
 all = [
@@ -85,6 +88,7 @@ all = [
     "tomlkit",
     "flake8",
     "dill",
+    "ruff",
 ]
 
 
@@ -93,6 +97,7 @@ parameterized = "^0.9.0"
 flake8 = "^7.1.1"
 pytest = "^8.3.4"
 pre-commit = "^4.1.0"
+ruff = "^0.11.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ pre-commit = "^4.1.0"
 ruff = "^0.11.0"
 
 [tool.ruff]
+line-length = 127
+
 [tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,13 @@ pre-commit = "^4.1.0"
 ruff = "^0.11.0"
 
 [tool.ruff]
-extend-flake8-codes = true  # until I can go and change some # noqa statements
-
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/tdwii_plus_examples/_dicom_uids.py
+++ b/tdwii_plus_examples/_dicom_uids.py
@@ -1,5 +1,5 @@
-from pynetdicom import AllStoragePresentationContexts
 from pydicom.uid import AllTransferSyntaxes
+from pynetdicom import AllStoragePresentationContexts
 
 UPS_SOP_CLASSES = {
     "UnifiedProcedureStepPush": "1.2.840.10008.5.1.4.34.6.1",

--- a/tdwii_plus_examples/cechoscp.py
+++ b/tdwii_plus_examples/cechoscp.py
@@ -1,9 +1,9 @@
-from argparse import Namespace
 import logging
+from argparse import Namespace
 
 from pynetdicom import evt
-from pynetdicom.sop_class import Verification
 from pynetdicom.apps.common import setup_logging
+from pynetdicom.sop_class import Verification
 
 from tdwii_plus_examples.basescp import BaseSCP
 from tdwii_plus_examples.cechohandler import handle_cecho
@@ -35,12 +35,7 @@ class CEchoSCP(BaseSCP):
             Adds handlers for DICOM communication events to the SCP instance.
     """
 
-    def __init__(self,
-                 ae_title: str = "ECHO_SCP",
-                 bind_address: str = "",
-                 port: int = 11112,
-                 logger=None,
-                 **kwargs):
+    def __init__(self, ae_title: str = "ECHO_SCP", bind_address: str = "", port: int = 11112, logger=None, **kwargs):
         """
         Initializes a new instance of the CEchoSCP class.
         This method creates an AE with the Verification presentation context.
@@ -64,35 +59,24 @@ class CEchoSCP(BaseSCP):
             Optional, default: None, a debug logger will be used.
         """
         if logger is None:
-            self.logger = setup_logging(
-                Namespace(log_type=None, log_level="debug"), "cecho_scp")
+            self.logger = setup_logging(Namespace(log_type=None, log_level="debug"), "cecho_scp")
             self.logger.info(
-                "Logger not provided, using default logger with level %s",
-                logging.getLevelName(self.logger.level)
+                "Logger not provided, using default logger with level %s", logging.getLevelName(self.logger.level)
             )
         elif isinstance(logger, logging.Logger):
             self.logger = logger
-            self.logger.debug(
-                "Logger set to %s with level %s",
-                logger.name, logging.getLevelName(logger.getEffectiveLevel())
-            )
+            self.logger.debug("Logger set to %s with level %s", logger.name, logging.getLevelName(logger.getEffectiveLevel()))
         else:
             raise TypeError("logger must be an instance of logging.Logger")
         self.logger.debug("CEchoSCP.__init__")
 
         if not ae_title:
             self.ae_title = "ECHO_SCP"
-            self.logger.info("AE title not provided, using default: %s",
-                             self.ae_title)
+            self.logger.info("AE title not provided, using default: %s", self.ae_title)
         else:
             self.ae_title = ae_title
 
-        super().__init__(
-            ae_title=self.ae_title,
-            bind_address=bind_address,
-            port=port,
-            logger=logger,
-            **kwargs)
+        super().__init__(ae_title=self.ae_title, bind_address=bind_address, port=port, logger=logger, **kwargs)
 
     def _add_contexts(self):
         """
@@ -120,5 +104,4 @@ class CEchoSCP(BaseSCP):
         """
         self.logger.debug("CEchoSCP._add_handlers")
         super()._add_handlers()
-        self.handlers.append((evt.EVT_C_ECHO, handle_cecho,
-                              [self.logger]))
+        self.handlers.append((evt.EVT_C_ECHO, handle_cecho, [self.logger]))

--- a/tdwii_plus_examples/cli/config_dump.py
+++ b/tdwii_plus_examples/cli/config_dump.py
@@ -11,10 +11,8 @@ Arguments:
 """
 
 import sys
-from tdwii_plus_examples.tdwii_config import (
-    load_ae_config, load_machine_map,
-    known_ae_ipaddr, known_ae_port, machine_ae_map
-)
+
+from tdwii_plus_examples.tdwii_config import known_ae_ipaddr, known_ae_port, load_ae_config, load_machine_map, machine_ae_map
 
 
 def main():
@@ -34,9 +32,7 @@ def main():
     for key in machine_ae_map:
         try:
             value = machine_ae_map[key]
-            print(f"Machine Name:{key} AE Title:{value} "
-                  f"IPAddr:{known_ae_ipaddr[value]} "
-                  f"Port:{known_ae_port[value]}")
+            print(f"Machine Name:{key} AE Title:{value} IPAddr:{known_ae_ipaddr[value]} Port:{known_ae_port[value]}")
         except KeyError as e:
             print(f"AE Title {value} not found in AE config file")
             print(f"Error: {e}")

--- a/tdwii_plus_examples/cli/upsscp/handlers.py
+++ b/tdwii_plus_examples/cli/upsscp/handlers.py
@@ -1,4 +1,5 @@
 """Event handlers for upsscp.py"""
+
 import copy
 import logging
 import os
@@ -105,20 +106,20 @@ def _add_filtered_subscriber(subscriber_ae_title: str, query: Dataset, logger=No
 def _remove_global_subscriber(subscriber_ae_title: str, deletion_lock: bool = False, logger=None):
     if subscriber_ae_title in _global_subscribers.keys():
         del _global_subscribers[subscriber_ae_title]
-        logger.info(f"Receiving AE Title {subscriber_ae_title} was unsubscribed " "from global subscription")
+        logger.info(f"Receiving AE Title {subscriber_ae_title} was unsubscribed from global subscription")
     else:
         if logger is not None:
-            logger.info(f"Receiving AE Title {subscriber_ae_title} was not subscribed " "from global subscription")
+            logger.info(f"Receiving AE Title {subscriber_ae_title} was not subscribed from global subscription")
     return
 
 
 def _remove_filtered_subscriber(subscriber_ae_title: str, query: Dataset = None, logger=None):
     if subscriber_ae_title in _filtered_subscribers.keys():
         del _filtered_subscribers[subscriber_ae_title]
-        logger.info(f"Receiving AE Title {subscriber_ae_title} was unsubscribed " "from filtered global subscription")
+        logger.info(f"Receiving AE Title {subscriber_ae_title} was unsubscribed from filtered global subscription")
     else:
         if logger is not None:
-            logger.info(f"Receiving AE Title {subscriber_ae_title} was not subscribed " "from filtered global subscription")
+            logger.info(f"Receiving AE Title {subscriber_ae_title} was not subscribed from filtered global subscription")
     return
 
 
@@ -647,8 +648,8 @@ def handle_naction(event, instance_dir, db_path, cli_config, logger):
 
                 if (
                     (transaction_uid is None)
-                    or (len(transaction_uid) == 0)  # noqa: W503,W504
-                    or (current_step_state != "SCHEDULED" and transaction_uid != stored_transaction_uid)  # noqa: W503,W504
+                    or (len(transaction_uid) == 0)
+                    or (current_step_state != "SCHEDULED" and transaction_uid != stored_transaction_uid)
                 ):
                     service_status = 0xC301
                     error_str = "Transaction UID is missing, zero length, or not valid"
@@ -1093,7 +1094,7 @@ def handle_ncreate(event, storage_dir, db_path, cli_config, logger):
 
         subscriber_ip_addr = tdwii_config.known_ae_ipaddr[globalsubscriber]
         subscriber_port = tdwii_config.known_ae_port[globalsubscriber]
-        logger.info(f"Requesting association with {globalsubscriber} " f"at {subscriber_ip_addr}:{subscriber_port}")
+        logger.info(f"Requesting association with {globalsubscriber} at {subscriber_ip_addr}:{subscriber_port}")
         assoc = ae.associate(
             subscriber_ip_addr,
             subscriber_port,

--- a/tdwii_plus_examples/tests/cli/test_echoscp.py
+++ b/tdwii_plus_examples/tests/cli/test_echoscp.py
@@ -1,24 +1,19 @@
-import unittest
-from unittest.mock import patch, MagicMock
 import argparse
-import sys
 import logging
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
 
 from tdwii_plus_examples.cli.echoscp import main
 
 
 class TestMainFunction(unittest.TestCase):
-
-    @patch('tdwii_plus_examples.cli.echoscp.CEchoSCP')
-    @patch('tdwii_plus_examples.cli.echoscp.argparse.ArgumentParser.parse_args')
+    @patch("tdwii_plus_examples.cli.echoscp.CEchoSCP")
+    @patch("tdwii_plus_examples.cli.echoscp.argparse.ArgumentParser.parse_args")
     def test_main(self, mock_parse_args, MockCEchoSCP):
         # Mock the arguments
         mock_parse_args.return_value = argparse.Namespace(
-            ae_title='TEST_AE',
-            bind_address='127.0.0.1',
-            port=12345,
-            verbose=False,
-            debug=True
+            ae_title="TEST_AE", bind_address="127.0.0.1", port=12345, verbose=False, debug=True
         )
 
         # Mock the CEchoSCP instance
@@ -26,25 +21,21 @@ class TestMainFunction(unittest.TestCase):
         mock_cechoscp_instance.run = MagicMock()
 
         # Run the main function
-        with patch.object(sys, 'argv', ['echoscp.py']):
-            with self.assertLogs('echoscp', level='DEBUG') as log:
+        with patch.object(sys, "argv", ["echoscp.py"]):
+            with self.assertLogs("echoscp", level="DEBUG") as log:
                 main(loop_forever=False)  # avoid the infinite loop
 
         # Check that CEchoSCP was initialized with the correct arguments
         MockCEchoSCP.assert_called_once_with(
-            ae_title='TEST_AE',
-            bind_address='127.0.0.1',
-            port=12345,
-            logger=logging.getLogger('echoscp')
+            ae_title="TEST_AE", bind_address="127.0.0.1", port=12345, logger=logging.getLogger("echoscp")
         )
 
         # Check that the run method was called
         mock_cechoscp_instance.run.assert_called_once()
 
         # Check the log output
-        self.assertIn(
-            'Starting up the DICOM Verification SCP...', log.output[0])
+        self.assertIn("Starting up the DICOM Verification SCP...", log.output[0])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/cli/test_storescp.py
+++ b/tdwii_plus_examples/tests/cli/test_storescp.py
@@ -1,63 +1,61 @@
-import unittest
-from unittest.mock import patch, MagicMock, Mock
 import argparse
-import sys
 import logging
+import sys
+import unittest
+from unittest.mock import MagicMock, Mock, patch
 
 from tdwii_plus_examples.cli.storescp import main
 
 
 class TestMainFunction(unittest.TestCase):
-
-    @patch('tdwii_plus_examples.cli.storescp.CStoreSCP')
-    @patch('tdwii_plus_examples.cli.storescp.argparse.ArgumentParser.parse_args')
+    @patch("tdwii_plus_examples.cli.storescp.CStoreSCP")
+    @patch("tdwii_plus_examples.cli.storescp.argparse.ArgumentParser.parse_args")
     def test_main(self, mock_parse_args, MockCStoreSCP):
         # Mock the arguments
         mock_parse_args.return_value = argparse.Namespace(
-            ae_title='TEST_AE',
-            bind_address='127.0.0.1',
+            ae_title="TEST_AE",
+            bind_address="127.0.0.1",
             port=12345,
-            sop_classes=['SecondaryCaptureImageStorage'],
-            transfer_syntaxes=['ExplicitVRLittleEndian'],
-            custom_handler='my_handler',
-            output_directory='/var/tmp/output',
+            sop_classes=["SecondaryCaptureImageStorage"],
+            transfer_syntaxes=["ExplicitVRLittleEndian"],
+            custom_handler="my_handler",
+            output_directory="/var/tmp/output",
             verbose=False,
-            debug=True
+            debug=True,
         )
 
         # Mock the custom handler function
-        mock_handler = Mock(name='my_handler')
+        mock_handler = Mock(name="my_handler")
 
         # Patch the place where the custom handler is used
-        with patch('tdwii_plus_examples.cli.storescp.my_handler', mock_handler):
+        with patch("tdwii_plus_examples.cli.storescp.my_handler", mock_handler):
             # Mock the CStoreSCP instance
             mock_cstorescp_instance = MockCStoreSCP.return_value
             mock_cstorescp_instance.run = MagicMock()
 
             # Run the main function
-            with patch.object(sys, 'argv', ['storescp.py']):
-                with self.assertLogs('storescp', level='DEBUG') as log:
+            with patch.object(sys, "argv", ["storescp.py"]):
+                with self.assertLogs("storescp", level="DEBUG") as log:
                     main(loop_forever=False)  # avoid the infinite loop
 
             # Check that CStoreSCP was initialized with the correct arguments
             MockCStoreSCP.assert_called_once_with(
-                ae_title='TEST_AE',
-                bind_address='127.0.0.1',
+                ae_title="TEST_AE",
+                bind_address="127.0.0.1",
                 port=12345,
-                logger=logging.getLogger('storescp'),
-                sop_classes=['SecondaryCaptureImageStorage'],
-                transfer_syntaxes=['ExplicitVRLittleEndian'],
+                logger=logging.getLogger("storescp"),
+                sop_classes=["SecondaryCaptureImageStorage"],
+                transfer_syntaxes=["ExplicitVRLittleEndian"],
                 custom_handler=mock_handler,  # Ensure this is the mock function
-                store_directory='/var/tmp/output'
+                store_directory="/var/tmp/output",
             )
 
             # Check that the run method was called
             mock_cstorescp_instance.run.assert_called_once()
 
             # Check the log output
-            self.assertIn(
-                'Starting up the DICOM Storage SCP...', log.output[0])
+            self.assertIn("Starting up the DICOM Storage SCP...", log.output[0])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/cli/test_upseventreceiver.py
+++ b/tdwii_plus_examples/tests/cli/test_upseventreceiver.py
@@ -1,65 +1,58 @@
-import unittest
-from unittest.mock import patch, MagicMock, Mock
 import argparse
-import sys
 import logging
+import sys
+import unittest
+from unittest.mock import MagicMock, Mock, patch
 
 from tdwii_plus_examples.cli.upseventreceiver import main
 
 
 class TestMainFunction(unittest.TestCase):
-
-    @patch('tdwii_plus_examples.cli.upseventreceiver.UPSNEventReceiver')
-    @patch(
-        'tdwii_plus_examples.cli.upseventreceiver.argparse.ArgumentParser.parse_args')
+    @patch("tdwii_plus_examples.cli.upseventreceiver.UPSNEventReceiver")
+    @patch("tdwii_plus_examples.cli.upseventreceiver.argparse.ArgumentParser.parse_args")
     def test_main(self, mock_parse_args, MockUPSNEventReceiver):
         # Mock the arguments
         mock_parse_args.return_value = argparse.Namespace(
-            ae_title='TEST_AE',
-            bind_address='127.0.0.1',
+            ae_title="TEST_AE",
+            bind_address="127.0.0.1",
             port=12345,
-            transfer_syntaxes=['ExplicitVRLittleEndian'],
-            callback='my_upsevent_callback',
+            transfer_syntaxes=["ExplicitVRLittleEndian"],
+            callback="my_upsevent_callback",
             verbose=False,
-            debug=True
+            debug=True,
         )
 
         # Mock the custom callback function
-        mock_callback = Mock(name='my_upsevent_callback')
+        mock_callback = Mock(name="my_upsevent_callback")
 
         # Patch the place where the custom callback is used
-        with patch(
-            'tdwii_plus_examples.cli.upseventreceiver.my_upsevent_callback',
-                mock_callback):
+        with patch("tdwii_plus_examples.cli.upseventreceiver.my_upsevent_callback", mock_callback):
             # Mock the UPSNEventReceiver instance
             mock_upseventreceiver_instance = MockUPSNEventReceiver.return_value
             mock_upseventreceiver_instance.run = MagicMock()
 
             # Run the main function
-            with patch.object(sys, 'argv', ['upseventreceiver.py']):
-                with self.assertLogs('upseventreceiver', level='DEBUG') as log:
+            with patch.object(sys, "argv", ["upseventreceiver.py"]):
+                with self.assertLogs("upseventreceiver", level="DEBUG") as log:
                     main(loop_forever=False)  # avoid the infinite loop
 
             # Check that UPSNEventReceiver was initialized with the
             # correct arguments
             MockUPSNEventReceiver.assert_called_once_with(
-                ae_title='TEST_AE',
-                bind_address='127.0.0.1',
+                ae_title="TEST_AE",
+                bind_address="127.0.0.1",
                 port=12345,
-                logger=logging.getLogger('upseventreceiver'),
-                transfer_syntaxes=['ExplicitVRLittleEndian'],
-                ups_event_callback=mock_callback
+                logger=logging.getLogger("upseventreceiver"),
+                transfer_syntaxes=["ExplicitVRLittleEndian"],
+                ups_event_callback=mock_callback,
             )
 
             # Check that the run method was called
             mock_upseventreceiver_instance.run.assert_called_once()
 
             # Check the log output
-            self.assertIn(
-                'Starting up the DICOM UPS Event Receiver (SCU) ...',
-                log.output[0]
-            )
+            self.assertIn("Starting up the DICOM UPS Event Receiver (SCU) ...", log.output[0])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test__dicom_uids.py
+++ b/tdwii_plus_examples/tests/test__dicom_uids.py
@@ -1,5 +1,7 @@
 import unittest
+
 from parameterized import parameterized
+
 from tdwii_plus_examples._dicom_uids import (
     validate_sop_classes,
     validate_transfer_syntaxes,
@@ -17,21 +19,20 @@ class TestValidateSOPClasses(unittest.TestCase):
     VALID_KEYWORD = "CTImageStorage"
     INVALID_NAME = "CT Storage"
 
-    @parameterized.expand([
-        ([VALID_UID], []),
-        ([VALID_NAME], []),
-        ([VALID_KEYWORD], []),
-        ([], [INVALID_NAME]),
-        ([], []),
-        ([VALID_UID, f"  {VALID_NAME}", VALID_KEYWORD], []),
-        ([VALID_UID, f"  {VALID_NAME}"], [VALID_NAME.replace(" ", "", 1)]),
-        ([], [INVALID_NAME, ""]),
-        ([VALID_UID, VALID_NAME], [INVALID_NAME]),
-    ])
-    def test_validate_sop_classes(self,
-                                  valid_sop_classes,
-                                  invalid_sop_classes
-                                  ):
+    @parameterized.expand(
+        [
+            ([VALID_UID], []),
+            ([VALID_NAME], []),
+            ([VALID_KEYWORD], []),
+            ([], [INVALID_NAME]),
+            ([], []),
+            ([VALID_UID, f"  {VALID_NAME}", VALID_KEYWORD], []),
+            ([VALID_UID, f"  {VALID_NAME}"], [VALID_NAME.replace(" ", "", 1)]),
+            ([], [INVALID_NAME, ""]),
+            ([VALID_UID, VALID_NAME], [INVALID_NAME]),
+        ]
+    )
+    def test_validate_sop_classes(self, valid_sop_classes, invalid_sop_classes):
         sop_classes = valid_sop_classes + invalid_sop_classes
         valid, invalid = validate_sop_classes(sop_classes)
         valid_expected = {}
@@ -43,28 +44,22 @@ class TestValidateSOPClasses(unittest.TestCase):
         self.assertEqual(valid, valid_expected)
         self.assertEqual(invalid, invalid_expected)
 
-    @parameterized.expand([
-        (["1.2.840.10008.1.2.1"], []),
-        (["ExplicitVRLittleEndian"], []),
-        (["Explicit VR Little Endian"], []),
-        ([], ["Invalid UID"]),
-        ([], []),
-        (["1.2.840.10008.1.2.1", "  Explicit VR Little Endian",
-         "ExplicitVRLittleEndian"], []),
-        (["ExplicitVRLittleEndian", "1.2.840.10008.1.2.1"],
-         ["Explicit VRLittleEndian"]),
-        ([], ["Invalid UID", ""]),
-        (["1.2.840.10008.1.2.1", "ExplicitVRLittleEndian"], ["Explicit"]),
-    ])
-    def test_validate_transfer_syntaxes(self,
-                                        valid_transfer_syntaxes,
-                                        invalid_transfer_syntaxes
-                                        ):
-        transfer_syntaxes = (
-            valid_transfer_syntaxes + invalid_transfer_syntaxes
-        )
-        valid, invalid = validate_transfer_syntaxes(
-            transfer_syntaxes)
+    @parameterized.expand(
+        [
+            (["1.2.840.10008.1.2.1"], []),
+            (["ExplicitVRLittleEndian"], []),
+            (["Explicit VR Little Endian"], []),
+            ([], ["Invalid UID"]),
+            ([], []),
+            (["1.2.840.10008.1.2.1", "  Explicit VR Little Endian", "ExplicitVRLittleEndian"], []),
+            (["ExplicitVRLittleEndian", "1.2.840.10008.1.2.1"], ["Explicit VRLittleEndian"]),
+            ([], ["Invalid UID", ""]),
+            (["1.2.840.10008.1.2.1", "ExplicitVRLittleEndian"], ["Explicit"]),
+        ]
+    )
+    def test_validate_transfer_syntaxes(self, valid_transfer_syntaxes, invalid_transfer_syntaxes):
+        transfer_syntaxes = valid_transfer_syntaxes + invalid_transfer_syntaxes
+        valid, invalid = validate_transfer_syntaxes(transfer_syntaxes)
         valid_expected = {}
         for syntax in valid_transfer_syntaxes:
             valid_expected[syntax.strip()] = self.EXPECTED_TRANSFER_SYNTAX_UID
@@ -75,5 +70,5 @@ class TestValidateSOPClasses(unittest.TestCase):
         self.assertEqual(invalid, invalid_expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test_basehandlers.py
+++ b/tdwii_plus_examples/tests/test_basehandlers.py
@@ -1,14 +1,15 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from tdwii_plus_examples.basehandlers import handle_open, handle_close
+
+from tdwii_plus_examples.basehandlers import handle_close, handle_open
 
 
 class TestHandleConnectionsEvents(unittest.TestCase):
-    @patch('logging.Logger')
+    @patch("logging.Logger")
     def test_handle_open(self, MockLogger):
         # Create a mock event
         mock_event = MagicMock()
-        mock_event.assoc.requestor.address = '127.0.0.1'
+        mock_event.assoc.requestor.address = "127.0.0.1"
         mock_event.assoc.requestor.port = 104
 
         # Create a mock logger
@@ -21,16 +22,14 @@ class TestHandleConnectionsEvents(unittest.TestCase):
         self.assertEqual(status, 0x0000)
 
         # Check that the logger was called with the correct message
-        mock_logger.info.assert_called_once_with(
-            'Successful connection from 127.0.0.1:104'
-        )
+        mock_logger.info.assert_called_once_with("Successful connection from 127.0.0.1:104")
 
-    @patch('logging.Logger')
+    @patch("logging.Logger")
     def test_handle_close(self, MockLogger):
         # Create a mock event
         mock_event = MagicMock()
-        mock_event.assoc.requestor.ae_title = 'TEST_AET'
-        mock_event.assoc.requestor.address = '127.0.0.1'
+        mock_event.assoc.requestor.ae_title = "TEST_AET"
+        mock_event.assoc.requestor.address = "127.0.0.1"
         mock_event.assoc.requestor.port = 104
 
         # Create a mock logger
@@ -43,10 +42,8 @@ class TestHandleConnectionsEvents(unittest.TestCase):
         self.assertEqual(status, 0x0000)
 
         # Check that the logger was called with the correct message
-        mock_logger.info.assert_called_once_with(
-            'Closed connection with TEST_AET@127.0.0.1:104'
-        )
+        mock_logger.info.assert_called_once_with("Closed connection with TEST_AET@127.0.0.1:104")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test_basescp_integration.py
+++ b/tdwii_plus_examples/tests/test_basescp_integration.py
@@ -1,12 +1,14 @@
-import unittest
 import logging
-from logging.handlers import MemoryHandler
-import subprocess
-import time
 import re
+import subprocess
 import sys
-from tdwii_plus_examples.basescp import BaseSCP
+import time
+import unittest
+from logging.handlers import MemoryHandler
+
 from pynetdicom.sop_class import Verification
+
+from tdwii_plus_examples.basescp import BaseSCP
 
 
 class CEchoSCP(BaseSCP):
@@ -19,18 +21,17 @@ class CEchoSCP(BaseSCP):
 
 
 class TestBaseSCP(unittest.TestCase):
-
     def setUp(self):
         # Set up the logger for the BaseSCP to DEBUG level
         # with a memory handler to store up to 100 log messages
-        self.scp_logger = logging.getLogger('basescp')
+        self.scp_logger = logging.getLogger("basescp")
         self.scp_logger.setLevel(logging.DEBUG)
         self.memory_handler = MemoryHandler(100)
         self.scp_logger.addHandler(self.memory_handler)
 
         # Set up the logger for this test to DEBUG level
         # with a stream handler to print the log messages to the console
-        self.test_logger = logging.getLogger('test_basescp')
+        self.test_logger = logging.getLogger("test_basescp")
         self.test_logger.setLevel(logging.DEBUG)
         self.stream_handler = logging.StreamHandler()
         self.test_logger.addHandler(self.stream_handler)
@@ -48,47 +49,39 @@ class TestBaseSCP(unittest.TestCase):
         python_executable = sys.executable
 
         # Send an echo request using pynetdicom's echoscu.py
-        subprocess.check_call([python_executable, '-m', 'pynetdicom',
-                               'echoscu', 'localhost', '11112',
-                               '-aet', 'ECHOSCU', '-aec', 'BASE_SCP'])
+        subprocess.check_call(
+            [python_executable, "-m", "pynetdicom", "echoscu", "localhost", "11112", "-aet", "ECHOSCU", "-aec", "BASE_SCP"]
+        )
 
         # Wait for 1 second to ensure the logs are generated
         time.sleep(1)
 
         # Get the log messages
-        log_messages = [record.getMessage() for record
-                        in self.memory_handler.buffer]
+        log_messages = [record.getMessage() for record in self.memory_handler.buffer]
 
         # Check the EVT_CONN_OPEN event log message
         self.test_logger.info("Searching for EVT_CONN_OPEN event log message")
-        pattern = r"^Successful connection from " + \
-                  r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
+        pattern = r"^Successful connection from " + r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
         matching_message = None
         for message in log_messages:
             if re.search(pattern, message):
                 matching_message = message
                 break
-        self.test_logger.info(
-            f"EVT_CONN_OPEN event log message found: {matching_message}")
-        self.assertIsNotNone(matching_message,
-                             "EVT_CONN_OPEN event log message not found")
+        self.test_logger.info(f"EVT_CONN_OPEN event log message found: {matching_message}")
+        self.assertIsNotNone(matching_message, "EVT_CONN_OPEN event log message not found")
         # Stop the SCP
         self.scp.stop()
 
         # Check the EVT_CONN_CLOSE event log message
         self.test_logger.info("Searching for EVT_CONN_CLOSE event log message")
-        pattern = r"^Closed connection with " + \
-                  r"([\w]+)@" + \
-                  r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
+        pattern = r"^Closed connection with " + r"([\w]+)@" + r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
         matching_message = None
         for message in log_messages:
             if re.search(pattern, message):
                 matching_message = message
                 break
-        self.test_logger.info(
-            f"EVT_CONN_CLOSE event log message found: {matching_message}")
-        self.assertIsNotNone(matching_message,
-                             "EVT_CONN_CLOSE event log message not found")
+        self.test_logger.info(f"EVT_CONN_CLOSE event log message found: {matching_message}")
+        self.assertIsNotNone(matching_message, "EVT_CONN_CLOSE event log message not found")
 
 
 if __name__ == "__main__":

--- a/tdwii_plus_examples/tests/test_basescp_unit.py
+++ b/tdwii_plus_examples/tests/test_basescp_unit.py
@@ -1,12 +1,13 @@
-import unittest
 import logging
+import unittest
 from logging.handlers import MemoryHandler
 from unittest.mock import MagicMock, patch
-from parameterized import parameterized
 
-from tdwii_plus_examples.basescp import BaseSCP
-from tdwii_plus_examples.basehandlers import handle_open, handle_close
+from parameterized import parameterized
 from pynetdicom import evt
+
+from tdwii_plus_examples.basehandlers import handle_close, handle_open
+from tdwii_plus_examples.basescp import BaseSCP
 
 
 class TestBaseSCP(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestBaseSCP(unittest.TestCase):
     def setUpClass(cls):
         # Set up the logger for this test case to DEBUG level
         # with a stream handler to print the log messages to the console
-        cls.test_logger = logging.getLogger('test_basescp')
+        cls.test_logger = logging.getLogger("test_basescp")
         cls.test_logger.setLevel(logging.INFO)
         cls.stream_handler = logging.StreamHandler()
         cls.test_logger.addHandler(cls.stream_handler)
@@ -22,13 +23,13 @@ class TestBaseSCP(unittest.TestCase):
     def setUp(self):
         # Set up the logger for the BaseSCP to DEBUG level
         # with a memory handler to store up to 100 log messages
-        self.scp_logger = logging.getLogger('basescp')
+        self.scp_logger = logging.getLogger("basescp")
         self.scp_logger.setLevel(logging.DEBUG)
         self.memory_handler = MemoryHandler(100)
         self.scp_logger.addHandler(self.memory_handler)
 
         # Patch the AE class to return a mock instance
-        self.patcher = patch('tdwii_plus_examples.basescp.AE', autospec=True)
+        self.patcher = patch("tdwii_plus_examples.basescp.AE", autospec=True)
         self.mock_ae_class = self.patcher.start()
         self.mock_ae = self.mock_ae_class.return_value
 
@@ -40,8 +41,8 @@ class TestBaseSCP(unittest.TestCase):
     # Parameterized unit tests for the constructor parameters
 
     # Define expected warnings text
-    W_PORT_104 = 'DICOM port 104 may need admin privileges'
-    W_PORT_REG = 'Registered port (1024-49151) may be used by others'
+    W_PORT_104 = "DICOM port 104 may need admin privileges"
+    W_PORT_REG = "Registered port (1024-49151) may be used by others"
 
     # Define test cases parameters
     test_cases = [
@@ -59,7 +60,7 @@ class TestBaseSCP(unittest.TestCase):
         (None, None, 104, "scp_logger", None, W_PORT_104),  # DICOM_WK_REG_PORT
         (None, None, 11112, "scp_logger", None, None),  # DICOM_REG_PORT
         (None, None, 11114, "scp_logger", None, None),  # UNASSIGNED_REG_PORT
-        ("SCP", "127.0.0.1", 104, "scp_logger", None, None)  # CUSTOM_PARAMS
+        ("SCP", "127.0.0.1", 104, "scp_logger", None, None),  # CUSTOM_PARAMS
     ]
 
     # Define a function to generate test names
@@ -67,52 +68,39 @@ class TestBaseSCP(unittest.TestCase):
         return f"{testcase_func.__name__}_{param_num}"
 
     @parameterized.expand(test_cases, name_func=custom_name_func)
-    def test_init_params(
-        self,
-        ae_title,
-        bind_address,
-        port,
-        logger_name,
-        expected_exception,
-        expected_warning
-    ):
+    def test_init_params(self, ae_title, bind_address, port, logger_name, expected_exception, expected_warning):
         logger = getattr(self, logger_name) if logger_name else None
 
         if expected_exception:
             with self.assertRaises(expected_exception) as exception_context:
                 BaseSCP(ae_title, bind_address, port, logger)
                 self.test_logger.info(
-                    "Raised expected exception: %s: %s" % (
-                        expected_exception.__name__,
-                        exception_context.exception))
+                    "Raised expected exception: %s: %s" % (expected_exception.__name__, exception_context.exception)
+                )
         else:
             scp = BaseSCP(ae_title, bind_address, port, logger)
 
             # Check ae_title
-            self.assertEqual(
-                scp.ae_title, "BASE_SCP" if not ae_title else ae_title)
+            self.assertEqual(scp.ae_title, "BASE_SCP" if not ae_title else ae_title)
 
             # Check bind_address
-            self.assertEqual(
-                scp.bind_address, "" if not bind_address else bind_address)
+            self.assertEqual(scp.bind_address, "" if not bind_address else bind_address)
 
             # Check port
-            self.assertEqual(
-                scp.port, 11112 if not port else port)
+            self.assertEqual(scp.port, 11112 if not port else port)
 
             # Check logger
             if logger is None:
-                self.assertEqual(scp.logger.name, 'base_scp')
+                self.assertEqual(scp.logger.name, "base_scp")
             else:
                 self.assertEqual(scp.logger.name, logger.name)
                 self.assertIsInstance(scp.logger, logging.Logger)
 
             # Check for expected warning
             self.memory_handler.flush()
-            log_output = [record.getMessage()
-                          for record in self.memory_handler.buffer]
+            log_output = [record.getMessage() for record in self.memory_handler.buffer]
             if expected_warning:
-                self.assertIn(f'{expected_warning}', log_output)
+                self.assertIn(f"{expected_warning}", log_output)
 
         # Print the log messages
         # for record in self.memory_handler.buffer:
@@ -122,57 +110,46 @@ class TestBaseSCP(unittest.TestCase):
     # Mock unit tests for the run method
 
     def test_run_success(self):
-        self.base_scp = BaseSCP(bind_address="localhost",
-                                logger=self.scp_logger)
+        self.base_scp = BaseSCP(bind_address="localhost", logger=self.scp_logger)
 
         self.mock_server = MagicMock()
         self.mock_ae.start_server.return_value = self.mock_server
         self.base_scp.run()
         self.mock_ae.start_server.assert_called_once_with(
-            ("localhost", 11112),
-            evt_handlers=self.base_scp.handlers,
-            block=False
+            ("localhost", 11112), evt_handlers=self.base_scp.handlers, block=False
         )
 
         # Check the log messages
         self.memory_handler.flush()
-        log_output = [record.getMessage()
-                      for record in self.memory_handler.buffer]
+        log_output = [record.getMessage() for record in self.memory_handler.buffer]
         # Print the log output for debugging
         # self.test_logger.info(f"Log output: {log_output}")
         self.assertIn("SCP server started successfully", log_output)
 
     def test_run_failure(self):
-        self.base_scp = BaseSCP(bind_address="localhost",
-                                logger=self.scp_logger)
+        self.base_scp = BaseSCP(bind_address="localhost", logger=self.scp_logger)
 
-        self.mock_ae.start_server.side_effect = Exception(
-            "Failed to start server")
+        self.mock_ae.start_server.side_effect = Exception("Failed to start server")
         self.base_scp.run()
         self.mock_ae.start_server.assert_called_once_with(
-            ("localhost", 11112),
-            evt_handlers=self.base_scp.handlers,
-            block=False
+            ("localhost", 11112), evt_handlers=self.base_scp.handlers, block=False
         )
 
         # Check the log messages
         self.memory_handler.flush()
-        log_output = [record.getMessage()
-                      for record in self.memory_handler.buffer]
+        log_output = [record.getMessage() for record in self.memory_handler.buffer]
         # Print the log output for debugging
         # self.test_logger.info(f"Log output: {log_output}")
-        self.assertIn(
-            "SCP server failed to start: Failed to start server", log_output)
+        self.assertIn("SCP server failed to start: Failed to start server", log_output)
 
     # Other unit tests
 
     def test_add_handlers(self):
-        self.base_scp = BaseSCP(bind_address="localhost",
-                                logger=self.scp_logger)
+        self.base_scp = BaseSCP(bind_address="localhost", logger=self.scp_logger)
         # Check that the handlers list contains the expected handlers
         expected_handlers = [
             (evt.EVT_CONN_OPEN, handle_open, [self.scp_logger]),
-            (evt.EVT_CONN_CLOSE, handle_close, [self.scp_logger])
+            (evt.EVT_CONN_CLOSE, handle_close, [self.scp_logger]),
         ]
 
         # Print the actual handlers for debugging

--- a/tdwii_plus_examples/tests/test_cechohandler.py
+++ b/tdwii_plus_examples/tests/test_cechohandler.py
@@ -1,17 +1,18 @@
 import unittest
 from unittest.mock import MagicMock, patch
+
 from tdwii_plus_examples.cechohandler import handle_cecho
 
 
 class TestHandleCEchoEvent(unittest.TestCase):
-    @patch('logging.Logger')
+    @patch("logging.Logger")
     def test_handle_cecho(self, MockLogger):
         # Create a mock event
         mock_event = MagicMock()
-        mock_event.assoc.requestor.ae_title = 'TEST_AET'
-        mock_event.assoc.requestor.address = '127.0.0.1'
+        mock_event.assoc.requestor.ae_title = "TEST_AET"
+        mock_event.assoc.requestor.address = "127.0.0.1"
         mock_event.assoc.requestor.port = 104
-        mock_event.timestamp.strftime.return_value = '2024-12-28 11:00:00'
+        mock_event.timestamp.strftime.return_value = "2024-12-28 11:00:00"
 
         # Create a mock logger
         mock_logger = MockLogger()
@@ -23,11 +24,8 @@ class TestHandleCEchoEvent(unittest.TestCase):
         self.assertEqual(status, 0x0000)
 
         # Check that the logger was called with the correct message
-        mock_logger.info.assert_called_once_with(
-            'Received C-ECHO request from TEST_AET@127.0.0.1:104 at '
-            '2024-12-28 11:00:00'
-        )
+        mock_logger.info.assert_called_once_with("Received C-ECHO request from TEST_AET@127.0.0.1:104 at 2024-12-28 11:00:00")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test_cechoscp_integration.py
+++ b/tdwii_plus_examples/tests/test_cechoscp_integration.py
@@ -1,26 +1,26 @@
-import sys
-import unittest
 import logging
-from logging.handlers import MemoryHandler
-import subprocess
-import time
 import re
+import subprocess
+import sys
+import time
+import unittest
+from logging.handlers import MemoryHandler
+
 from tdwii_plus_examples.cechoscp import CEchoSCP
 
 
 class TestCEchoSCP(unittest.TestCase):
-
     def setUp(self):
         # Set up the logger for the CEchoSCP to INFO level
         # with a memory handler to store up to 100 log messages
-        self.scp_logger = logging.getLogger('cechoscp')
+        self.scp_logger = logging.getLogger("cechoscp")
         self.scp_logger.setLevel(logging.INFO)
         self.memory_handler = MemoryHandler(100)
         self.scp_logger.addHandler(self.memory_handler)
 
         # Set up the logger for this test to DEBUG level
         # with a stream handler to print the log messages to the console
-        self.test_logger = logging.getLogger('test_cechoscp')
+        self.test_logger = logging.getLogger("test_cechoscp")
         self.test_logger.setLevel(logging.DEBUG)
         self.stream_handler = logging.StreamHandler()
         self.test_logger.addHandler(self.stream_handler)
@@ -36,30 +36,26 @@ class TestCEchoSCP(unittest.TestCase):
         python_executable = sys.executable
 
         # Send an echo request using pynetdicom's echoscu.py
-        subprocess.check_call([python_executable, '-m', 'pynetdicom',
-                               'echoscu', 'localhost', '11112',
-                               '-aet', 'ECHOSCU', '-aec', 'ECHO_SCP'])
+        subprocess.check_call(
+            [python_executable, "-m", "pynetdicom", "echoscu", "localhost", "11112", "-aet", "ECHOSCU", "-aec", "ECHO_SCP"]
+        )
 
         # Wait for 1 second to ensure the logs are generated
         time.sleep(1)
 
         # Get the log messages
-        log_messages = [record.getMessage() for record
-                        in self.memory_handler.buffer]
+        log_messages = [record.getMessage() for record in self.memory_handler.buffer]
 
         # Search for the EVT_C_ECHO event log message
         self.test_logger.info("Searching for EVT_C_ECHO event log message")
-        pattern = r"^Received C-ECHO request from ECHOSCU@" + \
-                  r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
+        pattern = r"^Received C-ECHO request from ECHOSCU@" + r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):([\w]{3,5})"
         matching_message = None
         for message in log_messages:
             if re.search(pattern, message):
                 matching_message = message
                 break
-        self.test_logger.info(
-            f"EVT_C_ECHO event log message found: {matching_message}")
-        self.assertIsNotNone(matching_message,
-                             "EVT_C_ECHO event log message not found")
+        self.test_logger.info(f"EVT_C_ECHO event log message found: {matching_message}")
+        self.assertIsNotNone(matching_message, "EVT_C_ECHO event log message not found")
 
         # Stop the SCP
         self.scp.stop()

--- a/tdwii_plus_examples/tests/test_cechoscp_unit.py
+++ b/tdwii_plus_examples/tests/test_cechoscp_unit.py
@@ -1,7 +1,8 @@
-import unittest
-from parameterized import parameterized
 import logging
+import unittest
 from logging.handlers import MemoryHandler
+
+from parameterized import parameterized
 from pynetdicom import evt
 from pynetdicom.sop_class import Verification
 
@@ -10,53 +11,47 @@ from tdwii_plus_examples.cechoscp import CEchoSCP
 
 
 class TestCEchoSCP(unittest.TestCase):
-
     def setUp(self):
         # Set up the logger for the BaseSCP to DEBUG level
         # with a memory handler to store up to 100 log messages
-        self.scp_logger = logging.getLogger('test_cechoscp')
+        self.scp_logger = logging.getLogger("test_cechoscp")
         self.scp_logger.setLevel(logging.DEBUG)
         self.memory_handler = MemoryHandler(100)
         self.scp_logger.addHandler(self.memory_handler)
 
         self.scp = CEchoSCP(logger=self.scp_logger)
 
-    @parameterized.expand([
-        ("ECHO_SCP", "", 11112, ""),
-        ("MY_SCP", "", 11112, "scp_logger"),
-        ("", "", 11112, "scp_logger"),
-        (None, "", 11112, "scp_logger"),
-    ])
+    @parameterized.expand(
+        [
+            ("ECHO_SCP", "", 11112, ""),
+            ("MY_SCP", "", 11112, "scp_logger"),
+            ("", "", 11112, "scp_logger"),
+            (None, "", 11112, "scp_logger"),
+        ]
+    )
     def test_init_params(self, ae_title, bind_address, port, logger_name):
         if logger_name:
             logger = getattr(self, logger_name)
         else:
             logger = None
 
-        scp = CEchoSCP(ae_title=ae_title, bind_address=bind_address,
-                       port=port, logger=logger)
+        scp = CEchoSCP(ae_title=ae_title, bind_address=bind_address, port=port, logger=logger)
 
-        self.assertEqual(
-            scp.ae_title, "ECHO_SCP" if not ae_title else ae_title)
+        self.assertEqual(scp.ae_title, "ECHO_SCP" if not ae_title else ae_title)
         self.assertEqual(scp.bind_address, bind_address)
         self.assertEqual(scp.port, port)
-        self.assertEqual(
-            scp.logger.name, "test_cechoscp" if logger_name else "base_scp")
+        self.assertEqual(scp.logger.name, "test_cechoscp" if logger_name else "base_scp")
 
     def test_add_contexts(self):
-        sop_class = [ctx.abstract_syntax
-                     for ctx in self.scp.ae.supported_contexts]
-        self.assertIn(Verification, sop_class,
-                      msg="Verification SOP Class not supported")
-        ts = [ctx.transfer_syntax for ctx in self.scp.ae.supported_contexts
-              if ctx.abstract_syntax == Verification]
-        self.assertEqual(ts[0], ['1.2.840.10008.1.2'],
-                         msg="Transfer syntax not as expected")
+        sop_class = [ctx.abstract_syntax for ctx in self.scp.ae.supported_contexts]
+        self.assertIn(Verification, sop_class, msg="Verification SOP Class not supported")
+        ts = [ctx.transfer_syntax for ctx in self.scp.ae.supported_contexts if ctx.abstract_syntax == Verification]
+        self.assertEqual(ts[0], ["1.2.840.10008.1.2"], msg="Transfer syntax not as expected")
 
     def test_add_handlers(self):
         handlers = [(evt.EVT_C_ECHO, handle_cecho, [self.scp_logger])]
         self.assertIn(handlers[0], self.scp.handlers)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test_cstorehandler.py
+++ b/tdwii_plus_examples/tests/test_cstorehandler.py
@@ -1,13 +1,15 @@
-import sys
-import unittest
-import tempfile
-import shutil
-import os
 import logging
+import os
+import shutil
+import sys
+import tempfile
+import unittest
 from unittest.mock import MagicMock, patch
+
 from parameterized import parameterized
-from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom import uid
+from pydicom.dataset import Dataset, FileMetaDataset
+
 from tdwii_plus_examples.cstorehandler import handle_cstore
 
 
@@ -15,8 +17,8 @@ def create_mock_dataset():
     ds = Dataset()
     ds.SOPClassUID = uid.SecondaryCaptureImageStorage
     ds.SOPInstanceUID = uid.generate_uid()
-    ds.PatientName = 'Test^Patient'
-    ds.PatientID = '123456'
+    ds.PatientName = "Test^Patient"
+    ds.PatientID = "123456"
     ds.StudyInstanceUID = uid.generate_uid()
     ds.SeriesInstanceUID = uid.generate_uid()
     return ds
@@ -46,31 +48,29 @@ class TestHandleCStoreEvent(unittest.TestCase):
         # Create a mock event
         self.mock_event = MagicMock()
         self.mock_event.dataset = create_mock_dataset()
-        self.mock_event.file_meta = create_mock_file_meta(
-            self.mock_event.dataset.SOPInstanceUID)
-        self.mock_event.context.transfer_syntax = '1.2.840.10008.1.2.1'
+        self.mock_event.file_meta = create_mock_file_meta(self.mock_event.dataset.SOPInstanceUID)
+        self.mock_event.context.transfer_syntax = "1.2.840.10008.1.2.1"
 
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.temp_dir)
 
-    @parameterized.expand([
-        (False, 'output', 0x0000),  # Status.SUCCESS
-        (True, 'output', 0x0000),   # Status.SUCCESS
-        (False, None, 0xC212),      # Status.MISSING_ARGUMENT
-        (False, 'output', 0xC210),  # Status.UNABLE_TO_DECODE_DATASET
-        (False, '/invalid/path\0', 0xA700),  # Status.OUT_OF_RESOURCES
-    ])
-    @patch('logging.Logger')
-    def test_handle_cstore(self, ignore, output_directory, expected_status,
-                           MockLogger):
-
+    @parameterized.expand(
+        [
+            (False, "output", 0x0000),  # Status.SUCCESS
+            (True, "output", 0x0000),  # Status.SUCCESS
+            (False, None, 0xC212),  # Status.MISSING_ARGUMENT
+            (False, "output", 0xC210),  # Status.UNABLE_TO_DECODE_DATASET
+            (False, "/invalid/path\0", 0xA700),  # Status.OUT_OF_RESOURCES
+        ]
+    )
+    @patch("logging.Logger")
+    def test_handle_cstore(self, ignore, output_directory, expected_status, MockLogger):
         # Create a mock args
         mock_args = MagicMock()
         mock_args.ignore = ignore
         if output_directory is not None:
-            mock_args.output_directory = os.path.join(
-                self.temp_dir, output_directory)
+            mock_args.output_directory = os.path.join(self.temp_dir, output_directory)
         else:
             mock_args.output_directory = None
 
@@ -88,41 +88,31 @@ class TestHandleCStoreEvent(unittest.TestCase):
         self.logger.debug(
             "\nTest case parameters:\n ignore = %s"
             "\n output_directory = %s"
-            "\n expected_status = 0x%04X" % (
-                ignore, mock_args.output_directory, expected_status))
+            "\n expected_status = 0x%04X" % (ignore, mock_args.output_directory, expected_status)
+        )
         self.logger.debug(
-            "\nTest case results:"
-            "\n actual status = 0x%04X"
-            "\n logger calls : %s," % (
-                status_ds.Status, mock_logger.mock_calls))
+            "\nTest case results:\n actual status = 0x%04X\n logger calls : %s," % (status_ds.Status, mock_logger.mock_calls)
+        )
 
         # Check the status
         self.assertEqual(status_ds.Status, expected_status)
 
         # Check that the logger was called with the correct messages
         if ignore:
-            mock_logger.info.assert_called_once_with(
-                "Ignoring C-STORE request")
+            mock_logger.info.assert_called_once_with("Ignoring C-STORE request")
         elif output_directory is None:
-            mock_logger.error.assert_called_once_with(
-                "args.output_directory attribute not present or None")
-        elif '/invalid/path' in output_directory:
-            expected_message = (
-                "Unable to create the output directory: /invalid/path\x00")
-            if sys.platform.startswith('win'):
-                expected_message = expected_message.replace(
-                    "/invalid/path", "C:/invalid/path"
-                )
+            mock_logger.error.assert_called_once_with("args.output_directory attribute not present or None")
+        elif "/invalid/path" in output_directory:
+            expected_message = "Unable to create the output directory: /invalid/path\x00"
+            if sys.platform.startswith("win"):
+                expected_message = expected_message.replace("/invalid/path", "C:/invalid/path")
             mock_logger.exception.assert_called_once_with(expected_message)
         elif expected_status == 0xC210:
-            mock_logger.exception.assert_called_once_with(
-                "Unable to decode the data set and/or the command set")
+            mock_logger.exception.assert_called_once_with("Unable to decode the data set and/or the command set")
         else:
             mock_logger.info.assert_any_call("Processing C-STORE request")
-            mock_logger.info.assert_any_call(
-                "Storing DICOM file: SC.%s.dcm"
-                % self.mock_event.dataset.SOPInstanceUID)
+            mock_logger.info.assert_any_call("Storing DICOM file: SC.%s.dcm" % self.mock_event.dataset.SOPInstanceUID)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tdwii_plus_examples/tests/test_cstorescp_integration.py
+++ b/tdwii_plus_examples/tests/test_cstorescp_integration.py
@@ -1,56 +1,44 @@
-import sys
-import unittest
-import tempfile
-import shutil
-import os
 import datetime
 import logging
-from logging.handlers import MemoryHandler
+import os
+import shutil
 import subprocess
+import sys
+import tempfile
 import time
+import unittest
+from logging.handlers import MemoryHandler
 
-from pydicom.dataset import FileMetaDataset, FileDataset
-from pydicom import uid
+from parameterized import parameterized
+from pydicom import dcmread, uid
+from pydicom.dataset import FileDataset, FileMetaDataset
 
 from tdwii_plus_examples.cstorescp import CStoreSCP
-from pydicom import dcmread
-from parameterized import parameterized
 
 
 class TestCStoreSCP(unittest.TestCase):
-
     def setUp(self):
         # Set up loggers
         self.memory_handler = MemoryHandler(100)
-        self.scp_logger = self._setup_logger(
-            'cstorescp', logging.DEBUG, self.memory_handler)
-        self.test_logger = self._setup_logger(
-            'test_cstorescp', logging.INFO, logging.StreamHandler())
+        self.scp_logger = self._setup_logger("cstorescp", logging.DEBUG, self.memory_handler)
+        self.test_logger = self._setup_logger("test_cstorescp", logging.INFO, logging.StreamHandler())
 
         # Create a temporary directory
         self.temp_dir = tempfile.mkdtemp()
 
         # Create a mock DICOM file
-        self.dataset_file_little_endian, self.ds = self._create_dicom_file(
-            self.temp_dir)
+        self.dataset_file_little_endian, self.ds = self._create_dicom_file(self.temp_dir)
 
         # Save the mock DICOM file
         self.ds.save_as(self.dataset_file_little_endian)
-        self.test_logger.info(
-            "Created temporary file with ExplicitVRLittleEndian: %s" %
-            self.dataset_file_little_endian
-        )
+        self.test_logger.info("Created temporary file with ExplicitVRLittleEndian: %s" % self.dataset_file_little_endian)
 
         # Save the same dataset in another file with ExplicitVRBigEndian
-        self.dataset_file_big_endian = os.path.join(
-            self.temp_dir, "mock_sc_image_big_endian.dcm")
+        self.dataset_file_big_endian = os.path.join(self.temp_dir, "mock_sc_image_big_endian.dcm")
         self.ds.is_little_endian = False
         self.ds.file_meta.TransferSyntaxUID = uid.ExplicitVRBigEndian
         self.ds.save_as(self.dataset_file_big_endian)
-        self.test_logger.info(
-            "Created temporary file with ExplicitVRBigEndian: %s" %
-            self.dataset_file_big_endian
-        )
+        self.test_logger.info("Created temporary file with ExplicitVRBigEndian: %s" % self.dataset_file_big_endian)
 
     def _setup_logger(self, name, level, handler):
         logger = logging.getLogger(name)
@@ -60,10 +48,8 @@ class TestCStoreSCP(unittest.TestCase):
 
     def _create_dicom_file(self, temp_dir):
         file_meta = self._get_file_meta()
-        dataset_file = os.path.join(
-            temp_dir, "mock_sc_image_little_endian.dcm")
-        ds = FileDataset(dataset_file, {}, file_meta=file_meta,
-                         preamble=b"\0" * 128)
+        dataset_file = os.path.join(temp_dir, "mock_sc_image_little_endian.dcm")
+        ds = FileDataset(dataset_file, {}, file_meta=file_meta, preamble=b"\0" * 128)
         self._add_metadata(ds)
         self._add_private_elements(ds)
         self._set_pixel_data(ds)
@@ -82,8 +68,8 @@ class TestCStoreSCP(unittest.TestCase):
     def _add_metadata(self, ds):
         ds.SOPClassUID = uid.SecondaryCaptureImageStorage
         ds.SOPInstanceUID = uid.generate_uid()
-        ds.PatientName = 'Test^Patient'
-        ds.PatientID = '123456'
+        ds.PatientName = "Test^Patient"
+        ds.PatientID = "123456"
         ds.StudyInstanceUID = uid.generate_uid()
         ds.SeriesInstanceUID = uid.generate_uid()
         dt = datetime.datetime.now()
@@ -106,11 +92,11 @@ class TestCStoreSCP(unittest.TestCase):
 
     def _add_private_elements(self, ds):
         # Reserve a private block
-        block = ds.private_block(0x0011, 'PrivateCreator', create=True)
+        block = ds.private_block(0x0011, "PrivateCreator", create=True)
         # Add private elements
-        block.add_new(0x01, 'DS', '123.456')  # Decimal String
-        block.add_new(0x02, 'FL', 789.0123456789)  # Float
-        block.add_new(0x03, 'FD', 789.0123456789)  # Double
+        block.add_new(0x01, "DS", "123.456")  # Decimal String
+        block.add_new(0x02, "FL", 789.0123456789)  # Float
+        block.add_new(0x03, "FD", 789.0123456789)  # Double
 
     def tearDown(self):
         # Remove the temporary directory and its contents
@@ -118,25 +104,27 @@ class TestCStoreSCP(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
         # Log the removal of the temporary directory
-        self.test_logger.info(
-            "Removed the temp directory: %s and its contents: %s" %
-            (self.temp_dir, files_in_temp_dir))
+        self.test_logger.info("Removed the temp directory: %s and its contents: %s" % (self.temp_dir, files_in_temp_dir))
 
-    @parameterized.expand([
-        ([],),
-        ([uid.ExplicitVRLittleEndian],),
-        ([uid.ImplicitVRLittleEndian],),
-        ([uid.ExplicitVRLittleEndian, uid.ImplicitVRLittleEndian],),
-        ([uid.ExplicitVRBigEndian, uid.ImplicitVRLittleEndian],),
-        ([uid.ImplicitVRLittleEndian, uid.ExplicitVRLittleEndian],),
-    ])
+    @parameterized.expand(
+        [
+            ([],),
+            ([uid.ExplicitVRLittleEndian],),
+            ([uid.ImplicitVRLittleEndian],),
+            ([uid.ExplicitVRLittleEndian, uid.ImplicitVRLittleEndian],),
+            ([uid.ExplicitVRBigEndian, uid.ImplicitVRLittleEndian],),
+            ([uid.ImplicitVRLittleEndian, uid.ExplicitVRLittleEndian],),
+        ]
+    )
     def test_run_and_check_log(self, transfer_syntaxes):
         # Create a CStoreSCP instance
-        self.scp = CStoreSCP(bind_address="localhost",
-                             store_directory=self.temp_dir,
-                             logger=self.scp_logger,
-                             sop_classes=[uid.SecondaryCaptureImageStorage],
-                             transfer_syntaxes=transfer_syntaxes)
+        self.scp = CStoreSCP(
+            bind_address="localhost",
+            store_directory=self.temp_dir,
+            logger=self.scp_logger,
+            sop_classes=[uid.SecondaryCaptureImageStorage],
+            transfer_syntaxes=transfer_syntaxes,
+        )
         # Run the SCP
         self.scp.run()
         self.test_logger.info("SCP started successfully")
@@ -152,9 +140,17 @@ class TestCStoreSCP(unittest.TestCase):
         # Send the dataset using pynetdicom's storescu.py
         subprocess.check_call(
             [
-                python_executable, '-m', 'pynetdicom', 'storescu',
-                'localhost', '11112', '-aet', 'STORESCU',
-                '-aec', 'STORE_SCP', self.dataset_file
+                python_executable,
+                "-m",
+                "pynetdicom",
+                "storescu",
+                "localhost",
+                "11112",
+                "-aet",
+                "STORESCU",
+                "-aec",
+                "STORE_SCP",
+                self.dataset_file,
             ]
         )
 
@@ -162,66 +158,37 @@ class TestCStoreSCP(unittest.TestCase):
         time.sleep(1)
 
         # Get the log messages
-        log_messages = [record.getMessage() for record
-                        in self.memory_handler.buffer]
+        log_messages = [record.getMessage() for record in self.memory_handler.buffer]
         self.test_logger.debug(f"Log messages: {log_messages}")
 
         # Check that the log messages contain the expected message
         filename = f"SC.{self.ds.SOPInstanceUID}.dcm"
-        self.assertIn(
-            f"Storing DICOM file: {filename}",
-            log_messages,
-            "Log messages do not contain the expected message"
-        )
+        self.assertIn(f"Storing DICOM file: {filename}", log_messages, "Log messages do not contain the expected message")
         # Check that the received dataset was stored
         file_path = os.path.join(self.temp_dir, filename)
-        self.assertTrue(os.path.isfile(file_path),
-                        f"The dataset {file_path} was not stored")
+        self.assertTrue(os.path.isfile(file_path), f"The dataset {file_path} was not stored")
 
         # Print the stored DICOM file content
         ds = dcmread(file_path)
         self.test_logger.debug(f"DICOM file content:\n{ds}")
 
         # Check that the private elements are present in the stored file
-        private_block = ds.private_block(0x0011, 'PrivateCreator')
-        self.assertIn(0x01, private_block,
-                      "Private element 0x00110001 not found")
-        self.assertIn(0x02, private_block,
-                      "Private element 0x00110002 not found")
-        if ds.file_meta.TransferSyntaxUID in [
-                uid.ExplicitVRLittleEndian, uid.ExplicitVRBigEndian]:
-            self.assertEqual(
-                private_block[0x01].value, '123.456',
-                "Private element 0x00110001 has incorrect value"
-            )
+        private_block = ds.private_block(0x0011, "PrivateCreator")
+        self.assertIn(0x01, private_block, "Private element 0x00110001 not found")
+        self.assertIn(0x02, private_block, "Private element 0x00110002 not found")
+        if ds.file_meta.TransferSyntaxUID in [uid.ExplicitVRLittleEndian, uid.ExplicitVRBigEndian]:
+            self.assertEqual(private_block[0x01].value, "123.456", "Private element 0x00110001 has incorrect value")
             self.assertAlmostEqual(
-                private_block[0x02].value, 789.0123456789, places=4,
-                msg="Private element 0x00110002 has incorrect value"
+                private_block[0x02].value, 789.0123456789, places=4, msg="Private element 0x00110002 has incorrect value"
             )
-            self.assertEqual(
-                private_block[0x03].value, 789.0123456789,
-                msg="Private element 0x00110003 has incorrect value"
-            )
+            self.assertEqual(private_block[0x03].value, 789.0123456789, msg="Private element 0x00110003 has incorrect value")
         else:
+            self.assertEqual(private_block[0x01].VR, "UN", "Private element 0x00110001 has incorrect VR")
+            self.assertEqual(private_block[0x01].value, b"123.456 ", "Private element 0x00110001 has incorrect value")
+            self.assertEqual(private_block[0x02].VR, "UN", "Private element 0x00110002 has incorrect VR")
+            self.assertEqual(private_block[0x02].value, b"\xca@ED", "Private element 0x00110002 has incorrect value")
             self.assertEqual(
-                private_block[0x01].VR, 'UN',
-                "Private element 0x00110001 has incorrect VR"
-            )
-            self.assertEqual(
-                private_block[0x01].value, b'123.456 ',
-                "Private element 0x00110001 has incorrect value"
-            )
-            self.assertEqual(
-                private_block[0x02].VR, 'UN',
-                "Private element 0x00110002 has incorrect VR"
-            )
-            self.assertEqual(
-                private_block[0x02].value, b'\xca@ED',
-                "Private element 0x00110002 has incorrect value"
-            )
-            self.assertEqual(
-                private_block[0x03].value, b'\xfb\xf8\xb0H\x19\xa8\x88@',
-                "Private element 0x00110003 has incorrect value"
+                private_block[0x03].value, b"\xfb\xf8\xb0H\x19\xa8\x88@", "Private element 0x00110003 has incorrect value"
             )
 
         # Stop the SCP

--- a/tdwii_plus_examples/tests/test_cstorescp_unit.py
+++ b/tdwii_plus_examples/tests/test_cstorescp_unit.py
@@ -1,66 +1,61 @@
 import logging
 import unittest
-from unittest.mock import Mock
 from logging.handlers import MemoryHandler
+from unittest.mock import Mock
+
 from parameterized import parameterized
 from pydicom import uid
-from pynetdicom import UID, DEFAULT_TRANSFER_SYNTAXES
+from pynetdicom import DEFAULT_TRANSFER_SYNTAXES, UID
 from pynetdicom.sop_class import Verification
+
+from tdwii_plus_examples._dicom_uids import validate_sop_classes, validate_transfer_syntaxes
 from tdwii_plus_examples.cstorescp import CStoreSCP
-from tdwii_plus_examples._dicom_uids import (
-    validate_sop_classes, validate_transfer_syntaxes
-)
 
 # Define test lists of valid and invalid SOP Classes and Transfer syntaxes
 # to be used in the parameterized test cases.
 SOP_CLASSES = [
-    "CTImageStorage",                 # valid Storage SOP Class Keyword
-    "MRStorage",                      # invalid Storage SOP Class Keyword
-    "RTIonPlanStorage",               # valid Storage SOP Class Keyword
+    "CTImageStorage",  # valid Storage SOP Class Keyword
+    "MRStorage",  # invalid Storage SOP Class Keyword
+    "RTIonPlanStorage",  # valid Storage SOP Class Keyword
     "1.2.840.10008.5.1.4.1.1.481.9",  # valid Storage SOP Class UID
-    "1.2.840.10008.1.2",              # invalid Storage SOP Class UID
-    "Verification",                   # invalid Storage SOP Class UID
+    "1.2.840.10008.1.2",  # invalid Storage SOP Class UID
+    "Verification",  # invalid Storage SOP Class UID
 ]
 
 XFER_SYNTAXES = [
     "ExplicitVRLittleEndian",  # valid transfer syntax Keyword
-    "1.2.840.10008.1.2.2",     # valid transfer syntax UID
-    "ImplicitLittleEndian",    # invalid transfer syntax Keyword
-    "1.2.840.10008.5.2.1",     # invalid transfer syntax UID
+    "1.2.840.10008.1.2.2",  # valid transfer syntax UID
+    "ImplicitLittleEndian",  # invalid transfer syntax Keyword
+    "1.2.840.10008.5.2.1",  # invalid transfer syntax UID
 ]
 
 
 class TestCStoreSCP(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         # Set up the logger for this test case to DEBUG level
         # with a stream handler to print the log messages to the console
-        cls.test_logger = logging.getLogger('test_cstorescp')
+        cls.test_logger = logging.getLogger("test_cstorescp")
         cls.test_logger.setLevel(logging.INFO)
         cls.stream_handler = logging.StreamHandler()
         cls.test_logger.addHandler(cls.stream_handler)
 
         # Get the valid and invalid items of the test lists
-        cls.valid_sop_classes, cls.invalid_sop_classes = \
-            validate_sop_classes(SOP_CLASSES)
+        cls.valid_sop_classes, cls.invalid_sop_classes = validate_sop_classes(SOP_CLASSES)
 
-        cls.valid_xfer_syntaxes, cls.invalid_xfer_syntaxes = \
-            validate_transfer_syntaxes(XFER_SYNTAXES)
+        cls.valid_xfer_syntaxes, cls.invalid_xfer_syntaxes = validate_transfer_syntaxes(XFER_SYNTAXES)
 
         # Get the list of default transfer syntaxes
         cls.default_transfer_syntaxes = DEFAULT_TRANSFER_SYNTAXES.copy()
         # Make ExplicitVRLittleEndian the preferred transfer syntax
         cls.default_transfer_syntaxes.remove(UID(uid.ExplicitVRLittleEndian))
-        cls.default_transfer_syntaxes = [UID(uid.ExplicitVRLittleEndian)] + \
-            cls.default_transfer_syntaxes
-        cls.test_logger.debug(f"Default Transfer Syntaxes: "
-                              f"{cls.default_transfer_syntaxes}")
+        cls.default_transfer_syntaxes = [UID(uid.ExplicitVRLittleEndian)] + cls.default_transfer_syntaxes
+        cls.test_logger.debug(f"Default Transfer Syntaxes: {cls.default_transfer_syntaxes}")
 
     def setUp(self):
         # Set up the logger for the BaseSCP to DEBUG level
         # with a memory handler to store up to 100 log messages
-        self.scp_logger = logging.getLogger('cstorescp')
+        self.scp_logger = logging.getLogger("cstorescp")
         self.scp_logger.setLevel(logging.INFO)
         self.memory_handler = MemoryHandler(100)
         self.scp_logger.addHandler(self.memory_handler)
@@ -72,19 +67,17 @@ class TestCStoreSCP(unittest.TestCase):
     # Parameterized unit tests for the constructor parameters
 
     # Define test cases parameters
-    @parameterized.expand([
-        (SOP_CLASSES, None, None, None),
-        (None, XFER_SYNTAXES, None, None),
-        (SOP_CLASSES, XFER_SYNTAXES, None, None),
-        (None, None, "custom_handler", None),
-        (None, None, "", None),
-        (None, None, None, "/path/to/store"),
-    ])
-    def test_init_params(self,
-                         sop_classes,
-                         transfer_syntaxes,
-                         custom_handler,
-                         store_directory):
+    @parameterized.expand(
+        [
+            (SOP_CLASSES, None, None, None),
+            (None, XFER_SYNTAXES, None, None),
+            (SOP_CLASSES, XFER_SYNTAXES, None, None),
+            (None, None, "custom_handler", None),
+            (None, None, "", None),
+            (None, None, None, "/path/to/store"),
+        ]
+    )
+    def test_init_params(self, sop_classes, transfer_syntaxes, custom_handler, store_directory):
         # Custom handler should be a function defined in the global namespace
         # at the module level, so we use globals() to look it up.
         # This allows passing a function name as a string argument.
@@ -98,45 +91,37 @@ class TestCStoreSCP(unittest.TestCase):
             sop_classes=sop_classes,
             transfer_syntaxes=transfer_syntaxes,
             custom_handler=handler,
-            store_directory=store_directory
+            store_directory=store_directory,
         )
         self.memory_handler.flush()
-        log_output = [record.getMessage()
-                      for record in self.memory_handler.buffer]
+        log_output = [record.getMessage() for record in self.memory_handler.buffer]
         # Print the log messages
         self.test_logger.debug(f"{log_output}")
 
         if transfer_syntaxes:
             # get the valid Transfer Syntax UIDs passed to the constructor
-            valid_xfer_stx_uids = list(
-                self.valid_xfer_syntaxes.copy().values()
-            )
+            valid_xfer_stx_uids = list(self.valid_xfer_syntaxes.copy().values())
             # add ImplicitVRLittleEndian to the list of valid Transfer Syntax
             # UIDs if it is not already present
             if uid.ImplicitVRLittleEndian not in valid_xfer_stx_uids:
                 valid_xfer_stx_uids.append(uid.ImplicitVRLittleEndian)
-            self.test_logger.debug(f"Expected Transfer Syntax UIDs: "
-                                   f"{valid_xfer_stx_uids}")
+            self.test_logger.debug(f"Expected Transfer Syntax UIDs: {valid_xfer_stx_uids}")
 
             # get the list of Transfer Syntax UIDs supported by the AE
             ae_supported_xfer_stx_uids = [
-                context.transfer_syntax
-                for context in scp.ae.supported_contexts
-                if context.abstract_syntax != Verification
+                context.transfer_syntax for context in scp.ae.supported_contexts if context.abstract_syntax != Verification
             ]
-            self.test_logger.debug(f"Supported Transfer Syntax UIDs: "
-                                   f"{ae_supported_xfer_stx_uids[0]}")
+            self.test_logger.debug(f"Supported Transfer Syntax UIDs: {ae_supported_xfer_stx_uids[0]}")
 
         if sop_classes:
             # get the valid SOP Class UIDs passed to the constructor
-            valid_sop_classes_uids = list(
-                self.valid_sop_classes.copy().values())
+            valid_sop_classes_uids = list(self.valid_sop_classes.copy().values())
 
             # get the list of Storage SOP Classes UIDs supported by the AE
             ae_supported_sop_classes_uids = [
                 context.abstract_syntax
                 for context in scp.ae.supported_contexts
-                if context.abstract_syntax.keyword != 'Verification'
+                if context.abstract_syntax.keyword != "Verification"
             ]
 
             # The set of SOP Classes supported by the AE should be the same
@@ -144,11 +129,13 @@ class TestCStoreSCP(unittest.TestCase):
             # We use assertCountEqual to check that the same elements are
             # present in both lists, regardless of order.
             self.assertCountEqual(
-                ae_supported_sop_classes_uids, valid_sop_classes_uids,
+                ae_supported_sop_classes_uids,
+                valid_sop_classes_uids,
                 msg=f"Supported SOP Classes in AE "
-                    f"({ae_supported_sop_classes_uids}) "
-                    f"do not match valid SOP Classes passed to constructor "
-                    f"({valid_sop_classes_uids})")
+                f"({ae_supported_sop_classes_uids}) "
+                f"do not match valid SOP Classes passed to constructor "
+                f"({valid_sop_classes_uids})",
+            )
 
             # Check transfer syntaxes
             for context in scp.ae.supported_contexts:
@@ -163,33 +150,38 @@ class TestCStoreSCP(unittest.TestCase):
                             msg=f"Supported transfer syntaxes for "
                             f"{context.abstract_syntax} "
                             f"do not match the pynetdicom defaults "
-                            f"({self.default_transfer_syntaxes})")
+                            f"({self.default_transfer_syntaxes})",
+                        )
                 else:
                     # Check specified transfer syntaxes are supported
-                    if context.abstract_syntax == '1.2.840.10008.1.1':
+                    if context.abstract_syntax == "1.2.840.10008.1.1":
                         pass  # skip as provided by parent class
                     else:
                         self.assertCountEqual(
-                            context.transfer_syntax, valid_xfer_stx_uids,
+                            context.transfer_syntax,
+                            valid_xfer_stx_uids,
                             msg=f"Supported transfer syntaxes for "
                             f"{context.abstract_syntax} "
                             f"do not match the specified transfer syntaxes"
-                            f"({valid_xfer_stx_uids})")
+                            f"({valid_xfer_stx_uids})",
+                        )
 
         elif transfer_syntaxes:
             # Check transfer syntaxes passed to the constructor are supported
             # by pynetdicom default SOP Classes
             for context in scp.ae.supported_contexts:
                 # Check default transfer syntaxes are supported
-                if context.abstract_syntax == '1.2.840.10008.1.1':
+                if context.abstract_syntax == "1.2.840.10008.1.1":
                     pass  # skip as provided by parent class
                 else:
                     self.assertCountEqual(
-                        context.transfer_syntax, valid_xfer_stx_uids,
+                        context.transfer_syntax,
+                        valid_xfer_stx_uids,
                         msg=f"Supported transfer syntaxes for "
                         f"{context.abstract_syntax} "
                         f"do not match the specified transfer syntaxes"
-                        f"({valid_xfer_stx_uids})")
+                        f"({valid_xfer_stx_uids})",
+                    )
         elif custom_handler:
             self.assertEqual(scp.handle_store, handler)
         elif store_directory:

--- a/tdwii_plus_examples/tests/test_upsneventreceiver_unit.py
+++ b/tdwii_plus_examples/tests/test_upsneventreceiver_unit.py
@@ -1,54 +1,50 @@
 import logging
 import unittest
-from unittest.mock import Mock
 from logging.handlers import MemoryHandler
+from unittest.mock import Mock
+
 from parameterized import parameterized
 from pydicom import uid
-from pynetdicom import UID, DEFAULT_TRANSFER_SYNTAXES
+from pynetdicom import DEFAULT_TRANSFER_SYNTAXES, UID
 from pynetdicom.sop_class import Verification
-from tdwii_plus_examples.upsneventreceiver import UPSNEventReceiver
+
+from tdwii_plus_examples._dicom_uids import UPS_SOP_CLASSES, validate_transfer_syntaxes
 from tdwii_plus_examples.upsneventhandler import nevent_callback
-from tdwii_plus_examples._dicom_uids import (
-    validate_transfer_syntaxes, UPS_SOP_CLASSES
-)
+from tdwii_plus_examples.upsneventreceiver import UPSNEventReceiver
 
 # Define test lists of valid and invalid Transfer syntaxes to be used in the parameterized test cases.
 XFER_SYNTAXES = [
     "ExplicitVRLittleEndian",  # valid transfer syntax Keyword
-    "1.2.840.10008.1.2.2",     # valid transfer syntax UID
-    "ImplicitLittleEndian",    # invalid transfer syntax Keyword
-    "1.2.840.10008.5.2.1",     # invalid transfer syntax UID
+    "1.2.840.10008.1.2.2",  # valid transfer syntax UID
+    "ImplicitLittleEndian",  # invalid transfer syntax Keyword
+    "1.2.840.10008.5.2.1",  # invalid transfer syntax UID
 ]
 
 
 class TestUPSNEventReceiver(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         # Set up the logger for this test case to DEBUG level
         # with a stream handler to print the log messages to the console
-        cls.test_logger = logging.getLogger('test_neventreceiver')
+        cls.test_logger = logging.getLogger("test_neventreceiver")
         cls.test_logger.setLevel(logging.INFO)
         cls.stream_handler = logging.StreamHandler()
         cls.test_logger.addHandler(cls.stream_handler)
 
         # Get the valid and invalid items of the test lists
-        cls.valid_xfer_syntaxes, cls.invalid_xfer_syntaxes = \
-            validate_transfer_syntaxes(XFER_SYNTAXES)
+        cls.valid_xfer_syntaxes, cls.invalid_xfer_syntaxes = validate_transfer_syntaxes(XFER_SYNTAXES)
 
         # Get the list of default transfer syntaxes
         cls.default_transfer_syntaxes = DEFAULT_TRANSFER_SYNTAXES.copy()
         # Make ExplicitVRLittleEndian the preferred transfer syntax
         cls.default_transfer_syntaxes.remove(UID(uid.ExplicitVRLittleEndian))
-        cls.default_transfer_syntaxes = [UID(uid.ExplicitVRLittleEndian)] + \
-            cls.default_transfer_syntaxes
-        cls.test_logger.debug(f"Default Transfer Syntaxes: "
-                              f"{cls.default_transfer_syntaxes}")
+        cls.default_transfer_syntaxes = [UID(uid.ExplicitVRLittleEndian)] + cls.default_transfer_syntaxes
+        cls.test_logger.debug(f"Default Transfer Syntaxes: {cls.default_transfer_syntaxes}")
 
     def setUp(self):
         # Set up the logger for the BaseSCP to DEBUG level
         # with a memory handler to store up to 100 log messages
-        self.rcv_logger = logging.getLogger('neventreceiver')
+        self.rcv_logger = logging.getLogger("neventreceiver")
         self.rcv_logger.setLevel(logging.INFO)
         self.memory_handler = MemoryHandler(100)
         self.rcv_logger.addHandler(self.memory_handler)
@@ -60,14 +56,14 @@ class TestUPSNEventReceiver(unittest.TestCase):
     # Parameterized unit tests for the constructor parameters
 
     # Define test cases parameters
-    @parameterized.expand([
-        (XFER_SYNTAXES, None),
-        (None, "custom_callback"),
-        (None, ""),
-    ])
-    def test_init_params(self,
-                         transfer_syntaxes,
-                         ups_event_callback):
+    @parameterized.expand(
+        [
+            (XFER_SYNTAXES, None),
+            (None, "custom_callback"),
+            (None, ""),
+        ]
+    )
+    def test_init_params(self, transfer_syntaxes, ups_event_callback):
         # Custom callback should be a function defined in the global namespace
         # at the module level, so we use globals() to look it up.
         # This allows passing a function name as a string argument.
@@ -82,59 +78,52 @@ class TestUPSNEventReceiver(unittest.TestCase):
             ups_event_callback=callback,
         )
         self.memory_handler.flush()
-        log_output = [record.getMessage()
-                      for record in self.memory_handler.buffer]
+        log_output = [record.getMessage() for record in self.memory_handler.buffer]
         # Print the log messages
         self.test_logger.debug(f"{log_output}")
 
         if transfer_syntaxes:
             # get the valid Transfer Syntax UIDs passed to the constructor
-            valid_xfer_stx_uids = list(
-                self.valid_xfer_syntaxes.copy().values()
-            )
+            valid_xfer_stx_uids = list(self.valid_xfer_syntaxes.copy().values())
             # add ImplicitVRLittleEndian to the list of valid Transfer Syntax
             # UIDs if it is not already present
             if uid.ImplicitVRLittleEndian not in valid_xfer_stx_uids:
                 valid_xfer_stx_uids.append(uid.ImplicitVRLittleEndian)
-            self.test_logger.debug(f"Expected Transfer Syntax UIDs: "
-                                   f"{valid_xfer_stx_uids}")
+            self.test_logger.debug(f"Expected Transfer Syntax UIDs: {valid_xfer_stx_uids}")
 
         # Check AE supports the UPSEventSOP and expected transfer syntaxes
         for context in receiver.ae.supported_contexts:
             if context.abstract_syntax != Verification:
-                self.test_logger.debug(f"Supported Abstract Syntax UIDs: "
-                                       f"{context.abstract_syntax}")
-                self.assertEqual(
-                    context.abstract_syntax,
-                    UPS_SOP_CLASSES["UnifiedProcedureStepEvent"]
-                )
+                self.test_logger.debug(f"Supported Abstract Syntax UIDs: {context.abstract_syntax}")
+                self.assertEqual(context.abstract_syntax, UPS_SOP_CLASSES["UnifiedProcedureStepEvent"])
             if not transfer_syntaxes:
                 # Check default transfer syntaxes are supported
                 if context.abstract_syntax == Verification:
                     pass  # skip as provided by parent class
                 else:
-                    self.test_logger.debug(f"Supported Transfer Syntax UIDs: "
-                                           f"{context.transfer_syntax}")
+                    self.test_logger.debug(f"Supported Transfer Syntax UIDs: {context.transfer_syntax}")
                     self.assertCountEqual(
                         context.transfer_syntax,
                         self.default_transfer_syntaxes,
                         msg=f"Supported transfer syntaxes for "
                         f"{context.abstract_syntax} "
                         f"do not match the pynetdicom defaults "
-                        f"({self.default_transfer_syntaxes})")
+                        f"({self.default_transfer_syntaxes})",
+                    )
             else:
                 # Check specified transfer syntaxes are supported
                 if context.abstract_syntax == Verification:
                     pass  # skip as provided by parent class
                 else:
-                    self.test_logger.debug(f"Supported Transfer Syntax UIDs: "
-                                           f"{context.transfer_syntax}")
+                    self.test_logger.debug(f"Supported Transfer Syntax UIDs: {context.transfer_syntax}")
                     self.assertCountEqual(
-                        context.transfer_syntax, valid_xfer_stx_uids,
+                        context.transfer_syntax,
+                        valid_xfer_stx_uids,
                         msg=f"Supported transfer syntaxes for "
                         f"{context.abstract_syntax} "
                         f"do not match the specified transfer syntaxes"
-                        f"({valid_xfer_stx_uids})")
+                        f"({valid_xfer_stx_uids})",
+                    )
 
         if ups_event_callback:
             self.test_logger.debug("Asserting custom callback is set")


### PR DESCRIPTION
## Summary by Sourcery

Switch to using Ruff for linting and formatting Python code, replacing flake8, black, and isort. This change includes updating the pre-commit configuration and removing the old linting tools.