### PR TITLE
update poetry to 2.1.1

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1.4.1
       with:
-        version: 1.5.0
+        version: 2.1.1
         virtualenvs-create: true
     - name: Configure poetry
       run: |


### PR DESCRIPTION
this can cause breakage from 1.x to 2.x, but I have this working in my environment with 2.1.1

## Summary by Sourcery

CI:
- Updates the Poetry version in the CI workflow to 2.1.1.