### PR TITLE
Improve UPSWatchNActionSCU

### DIFF
--- a/tdwii_plus_examples/tests/test_upswatchnactionscu_unit.py
+++ b/tdwii_plus_examples/tests/test_upswatchnactionscu_unit.py
@@ -111,6 +111,7 @@ class TestUPSWatchNActionSCU(unittest.TestCase):
                 action_type=action_type_id,
                 class_uid=UnifiedProcedureStepPush,
                 instance_uid=self.assoc.send_n_action.call_args[1]["instance_uid"],
+                meta_uid=UnifiedProcedureStepWatch,
             )
 
             # Verify the call to _handle_response

--- a/tdwii_plus_examples/upswatchnactionscu.py
+++ b/tdwii_plus_examples/upswatchnactionscu.py
@@ -78,7 +78,7 @@ class UPSWatchNActionSCU(BaseSCU):
         super()._add_requested_context()
         self.ae.add_requested_context(UnifiedProcedureStepWatch)
         self.logger.debug(
-            "Verification Presentation context added:\n" + "\n".join(str(ctx) for ctx in self.ae.requested_contexts)
+            "UPS Watch Presentation context added:\n" + "\n".join(str(ctx) for ctx in self.ae.requested_contexts)
         )
 
     def _send_upswatchnaction_request(
@@ -94,6 +94,8 @@ class UPSWatchNActionSCU(BaseSCU):
 
         Parameters
         ----------
+        assoc : Association
+            The Association object representing the established connection to the SCP.
         action_type_id : int
             The *Action Type ID* to use.
         instance_uid: pydicom.uid.UID
@@ -169,6 +171,7 @@ class UPSWatchNActionSCU(BaseSCU):
             action_type=action_type_id,
             class_uid=UnifiedProcedureStepPush,
             instance_uid=instance_uid,
+            meta_uid=UnifiedProcedureStepWatch,
         )
 
         return self._handle_response(rsp_status, action_reply)


### PR DESCRIPTION
This merge request addresses part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It slightly improves the changes merged in https://github.com/sjswerdloff/tdwii_plus_examples/pull/94

- Use meta_uid in send_action to remove a pynetdicom warning
- Correct a copy/paste error in a debug message
- Completes a docstring for a missing arg

## Summary by Sourcery

Improve UPS Watch N-Action SCU functionality by addressing minor issues and enhancing method documentation

Bug Fixes:
- Corrected a copy-paste error in a debug message log text
- Added missing meta_uid parameter to remove pynetdicom warning

Enhancements:
- Updated docstring for _send_upswatchnaction_request method to include missing argument description