### PR TITLE
Refactor ncreatescu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ scratchpad/
 # MacOS
 .DS_Store
 .qodo
+
+# Sourcery
+.sourcery.yaml

--- a/tdwii_plus_examples/cli/upscreatescu.py
+++ b/tdwii_plus_examples/cli/upscreatescu.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""
+A DICOM UPS Push Service Class Provider (SCU) application.
+
+This application implements a UPS Push N-CREATE SOP Class SCU.
+It uses the DIMSE N-CREATE Service to create UPS instances on a remote SCP.
+
+Usage:
+    upspushncreatescu [options] ip port path
+
+Arguments:
+    ip    IP address of called AE
+    port  TCP port number of called AE
+    path  DICOM file or directory containing UPS instances to create
+
+Options:
+    -h, --help               Show this help message and exit
+    -aet, --ae_title         Application Entity Title (default: UPSPUSHSCU)
+    -aec, --called_ae_title  Called Application Entity Title (default: ANYSCP)
+    -e, --echo               Verification of DICOM connection with Called AET
+    -v, --verbose            Set log level to INFO
+    -d, --debug              Set log level to DEBUG
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from pydicom import dcmread
+from pynetdicom.apps.common import get_files
+
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
+
+
+def get_contexts(fpaths, app_logger):
+    """Return the valid DICOM files and their context values.
+
+    Parameters
+    ----------
+    fpaths : list of str
+        A list of paths to the files to try and get data from.
+
+    Returns
+    -------
+    list of str, dict
+        A list of paths to valid DICOM files and the {SOP Class UID :
+        [Transfer Syntax UIDs]} that can be used to create the required
+        presentation contexts.
+    """
+    good, bad = [], []
+    contexts = {}
+    for fpath in fpaths:
+        path = os.fspath(Path(fpath).resolve())
+        try:
+            ds = dcmread(path)
+        except Exception:
+            bad.append(("Bad DICOM file", path))
+            continue
+
+        try:
+            sop_class = ds.SOPClassUID
+            tsyntax = ds.file_meta.TransferSyntaxUID
+        except Exception:
+            bad.append(("Unknown SOP Class or Transfer Syntax UID", path))
+            continue
+
+        tsyntaxes = contexts.setdefault(sop_class, [])
+        if tsyntax not in tsyntaxes:
+            tsyntaxes.append(tsyntax)
+
+        good.append(path)
+
+    for reason, path in bad:
+        app_logger.error(f"{reason}: {path}")
+
+    return good, contexts
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a DICOM UPS Push N-CREATE request")
+    parser.add_argument("ip", type=str, help="IP address or hotname of called AE")
+    parser.add_argument("port", type=int, help="TCP port number of called AE")
+    parser.add_argument(
+        "path", metavar="path", nargs="+", help="DICOM file or directory containing UPS instances to create", type=str
+    )
+    parser.add_argument("-r", "--recurse", help="recursively search the given directory", action="store_true")
+    parser.add_argument("-aet", "--ae_title", type=str, default="UPSPUSHSCU", help="Application Entity Title")
+    parser.add_argument("-aec", "--called_ae_title", type=str, default="ANYSCP", help="Called Application Entity Title")
+    parser.add_argument("-e", "--echo", action="store_true", help="Verification of DICOM connection with Called AET")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Set log level to INFO")
+    parser.add_argument("-d", "--debug", action="store_true", help="Set log level to DEBUG")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
+
+    args = parser.parse_args()
+
+    if args.quiet:
+        log_level = logging.CRITICAL
+    elif args.verbose:
+        log_level = logging.INFO
+    elif args.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.WARNING
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger("upspushncreatescu")
+    logger.setLevel(log_level)
+
+    logger.info(f"Initializing UPSPushCreateSCU instance with remote SCP {args.called_ae_title}@{args.ip}:{args.port}")
+    scu = UPSPushNCreateSCU(
+        logger=logger,
+        calling_ae_title=args.ae_title,
+        called_ip=args.ip,
+        called_port=args.port,
+        called_ae_title=args.called_ae_title,
+    )
+
+    # Verification requested
+    if args.echo:
+        print("Verification (C-ECHO) request")
+        result = scu.verify()
+        if result.status_category == "Success":
+            print("Verification (C-ECHO) successful")
+        else:
+            print(f"Verification (C-ECHO) failed: {result.status_description}")
+
+    # UPS instances creation requested
+    elif args.path is not None:
+        lfiles, badfiles = get_files(args.path, args.recurse)
+
+        for bad in badfiles:
+            logger.error(f"Cannot access path: {bad}")
+
+        # TODO: restrict SCU to required transfer syntaxes only
+        # this could be achieved by adding the required transfer syntaxes to the
+        # initialization of the SCU instance and reading the required transfer syntaxes
+        # from the file meta information of the DICOM files
+        lfiles, contexts = get_contexts(lfiles, logger)
+
+        if not lfiles:
+            logger.warning("No suitable DICOM files found")
+            sys.exit()
+
+        instances = []
+        for fpath in lfiles:
+            logger.info(f"Sending file: {fpath}")
+            try:
+                ds = dcmread(fpath, force=True)  # set force flag to allow raw DICOM files
+                instances.append(ds)
+            except Exception as e:
+                logger.error(f"Failed to read DICOM file {fpath}: {e}")
+                continue
+
+        result = scu.create_ups_instances(instances)
+
+        if result != 0:
+            print("UPS creation successful")
+        else:
+            print("UPS creation failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
+++ b/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
@@ -180,7 +180,7 @@ class MainBDIWidget(QWidget):
         )
         write_ups(ups, Path(self.ui.lineedit_bdidir_selector.text()))
         tms_ae_title = self.ui.line_edit_tms_scp_ae_title.text()
-        if tms_ae_title is None or str(tms_ae_title.strip()) == 0:
+        if tms_ae_title is None or len(str(tms_ae_title.strip())) == 0:
             self.logger.warning("No TMS AE Title specified, will not attempt an N-CREATE")
         else:
             dest_ae_title = tms_ae_title.strip()

--- a/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
+++ b/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QWidget,
 )
 
-from tdwii_plus_examples.rtbdi_creator.ncreatescu import NCreateSCU
+from tdwii_plus_examples import tdwii_config
 from tdwii_plus_examples.rtbdi_creator.rtbdi_factory import (
     create_rtbdi_from_rtion_plan,
     create_ups_from_plan_and_bdi,
@@ -33,6 +33,7 @@ from tdwii_plus_examples.rtbdi_creator.storescu import StoreSCU
 #     pyside6-uic form.ui -o ui_form.py, or
 #     pyside2-uic form.ui -o ui_form.py
 from tdwii_plus_examples.rtbdi_creator.ui_form import Ui_MainBDIWidget
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
 
 
 class MainBDIWidget(QWidget):
@@ -58,6 +59,8 @@ class MainBDIWidget(QWidget):
         self.ui.push_button_export_bdi.clicked.connect(self._bdi_export_button_clicked)
         self.ui.push_button_export_ups.clicked.connect(self._export_ups_button_clicked)
         self.ui.push_button_send_plan.clicked.connect(self._store_plan_button_clicked)
+
+        self.logger = logging.getLogger(__name__)
 
         self.plan = None
         self.plan_path = Path("~/").expanduser()
@@ -87,10 +90,10 @@ class MainBDIWidget(QWidget):
                     self.ui.line_edit_tms_scp_ae_title.setText(default_dict["ups_scp_ae_title"])
 
             else:
-                logging.warning("No [DEFAULT] section in toml config file")
+                self.logger.warning("No [DEFAULT] section in toml config file")
 
         except OSError as config_file_error:
-            logging.exception("Problem parsing config file: " + config_file_error)
+            self.logger.exception("Problem parsing config file: " + config_file_error)
 
     @Slot()
     def _plan_button_clicked(self):
@@ -136,7 +139,7 @@ class MainBDIWidget(QWidget):
         fraction_number = round(self.ui.double_spin_box_fraction_number.value())
         scheduled_date = self.ui.datetime_edit_scheduled_datetime.date()
         scheduled_time = self.ui.datetime_edit_scheduled_datetime.time()
-        print(f"Fraction Number: {fraction_number} " f"Scheduled Date: {scheduled_date} " f"Scheduled Time: {scheduled_time}")
+        print(f"Fraction Number: {fraction_number} Scheduled Date: {scheduled_date} Scheduled Time: {scheduled_time}")
         plan = load_plan(self.ui.lineedit_plan_selector.text())
         self.plan = plan
         fraction_number = round(self.ui.double_spin_box_fraction_number.value())
@@ -178,13 +181,23 @@ class MainBDIWidget(QWidget):
         write_ups(ups, Path(self.ui.lineedit_bdidir_selector.text()))
         tms_ae_title = self.ui.line_edit_tms_scp_ae_title.text()
         if tms_ae_title is None or str(tms_ae_title.strip()) == 0:
-            logging.warning("No TMS AE Title specified, will not attempt an N-CREATE")
+            self.logger.warning("No TMS AE Title specified, will not attempt an N-CREATE")
         else:
-            ncreate_scu = NCreateSCU(self.ae_title, tms_ae_title.strip())
+            dest_ae_title = tms_ae_title.strip()
+            tdwii_config.load_ae_config()
+            ip_addr = tdwii_config.known_ae_ipaddr[dest_ae_title]
+            port = tdwii_config.known_ae_port[dest_ae_title]
+            ncreate_scu = UPSPushNCreateSCU(
+                logger=self.logger,
+                calling_ae_title=self.ae_title,
+                called_ip=ip_addr,
+                called_port=port,
+                called_ae_title=dest_ae_title,
+            )
             ups_list = list()
             ups_list.append(ups)
-            success = ncreate_scu.create_ups(iods=ups_list)
-            self._command_outcome_message(success=success, command_name="N-CREATE")
+            num_created_inst = ncreate_scu.create_ups_instances(ups_list)
+            self._command_outcome_message(success=num_created_inst == len(ups_list), command_name="N-CREATE")
 
     def _command_outcome_message(self, success: bool, command_name: str, text: str = None):
         # apparently a known defect, see:

--- a/tdwii_plus_examples/tests/cli/test_upscreatescu.py
+++ b/tdwii_plus_examples/tests/cli/test_upscreatescu.py
@@ -1,0 +1,89 @@
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+# Import the main function from upscreatescu.py
+from tdwii_plus_examples.cli.upscreatescu import main
+
+
+class TestUPSCreateSCU(unittest.TestCase):
+    @patch("tdwii_plus_examples.cli.upscreatescu.UPSPushNCreateSCU")
+    @patch("sys.argv", new=["upscreatescu.py", "127.0.0.1", "104", "test_path", "-e"])
+    def test_echo_success(self, mock_scu):
+        """Test Verification option"""
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.verify.return_value.status_category = "Success"
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+            output = mock_stdout.getvalue()
+
+        self.assertIn("Verification (C-ECHO) successful", output)
+        mock_scu_instance.verify.assert_called_once()
+
+    @patch("tdwii_plus_examples.cli.upscreatescu.UPSPushNCreateSCU")
+    @patch("tdwii_plus_examples.cli.upscreatescu.get_files")
+    @patch("tdwii_plus_examples.cli.upscreatescu.dcmread")
+    @patch("sys.argv", new=["upscreatescu.py", "127.0.0.1", "104", "test_path"])
+    def test_create_ups_instances(self, mock_dcmread, mock_get_files, mock_scu):
+        """Test UPS Push creation of UPS instances."""
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.create_ups_instances.return_value = 1
+
+        # Mock get_files to return exactly one valid file and one invalid file
+        mock_get_files.return_value = (["valid_file.dcm"], ["invalid_file.dcm"])
+
+        # Mock dcmread to return a valid dataset for the valid file
+        mock_dcmread.return_value = MagicMock()
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+            output = mock_stdout.getvalue()
+
+        # Assert that the success message is printed
+        self.assertIn("UPS creation successful", output)
+
+        # Assert that create_ups_instances is called once
+        mock_scu_instance.create_ups_instances.assert_called_once()
+
+    @patch("tdwii_plus_examples.cli.upscreatescu.get_files")
+    @patch("tdwii_plus_examples.cli.upscreatescu.dcmread")
+    @patch("sys.argv", new=["upscreatescu.py", "127.0.0.1", "11114", "test_path"])
+    def test_no_valid_files(self, mock_dcmread, mock_get_files):
+        """Test error case where no valid DICOM files are found."""
+        mock_get_files.return_value = ([], ["invalid_file.dcm"])
+
+        with self.assertLogs("upspushncreatescu", level="WARNING") as log:
+            with self.assertRaises(SystemExit):
+                main()
+
+        # Assert that the warning message is in the logs
+        self.assertIn("No suitable DICOM files found", log.output[-1])
+        mock_dcmread.assert_not_called()
+
+    @patch("tdwii_plus_examples.cli.upscreatescu.get_files")
+    @patch("tdwii_plus_examples.cli.upscreatescu.get_contexts")
+    @patch("tdwii_plus_examples.cli.upscreatescu.dcmread")
+    @patch("sys.argv", new=["upscreatescu.py", "127.0.0.1", "11114", "test_path"])
+    def test_failed_dcmread(self, mock_dcmread, mock_get_contexts, mock_get_files):
+        """Test error case where DICOM file reading fails."""
+        # Mock get_files to return one valid file
+        mock_get_files.return_value = (["valid_file.dcm"], [])
+
+        # Mock get_contexts to return the valid file and contexts
+        mock_get_contexts.return_value = (["valid_file.dcm"], MagicMock())
+
+        # Mock dcmread to raise an exception for the valid file
+        mock_dcmread.side_effect = Exception("Failed to read file")
+
+        with self.assertLogs("upspushncreatescu", level="ERROR") as log:
+            main()
+
+        # Assert that the error message is in the logs
+        self.assertIn("Failed to read DICOM file valid_file.dcm", log.output[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
@@ -1,0 +1,107 @@
+import logging
+import subprocess
+import sys
+import time
+import unittest
+from logging.handlers import MemoryHandler
+
+from parameterized import parameterized
+from pydicom import Dataset
+from pydicom.uid import generate_uid
+
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
+
+
+class TestUPSPushNCreateSCU(unittest.TestCase):
+    def setUp(self):
+        # Set up the logger for the UPSPushNCreateSCU to INFO level
+        # with a memory handler to store up to 100 log messages
+        self.scu_logger = logging.getLogger("upspushscu")
+        self.scu_logger.setLevel(logging.DEBUG)
+        self.memory_handler = MemoryHandler(100)
+        self.scu_logger.addHandler(self.memory_handler)
+
+        # Set up the logger for this test to DEBUG level
+        # with a stream handler to print the log messages to the console
+        self.test_logger = logging.getLogger("test_upspushscu")
+        self.test_logger.setLevel(logging.DEBUG)
+        self.stream_handler = logging.StreamHandler()
+        self.test_logger.addHandler(self.stream_handler)
+
+        # Create a UPSPushNCreateSCU instance
+        self.upspush_ncreate_scu = UPSPushNCreateSCU(
+            calling_ae_title="UPSPUSH",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=self.scu_logger,
+        )
+
+        # Create a UPS instance for testing
+        self.ups_instance = Dataset()
+        self.ups_instance.PatientName = "Test^Patient"
+        self.ups_instance.PatientID = "123456"
+        self.ups_instance.SOPClassUID = "1.2.840.10008.5.1.4.34.6.1"
+        self.ups_instance.SOPInstanceUID = generate_uid()
+        self.ups_instance.ProcedureStepState = "SCHEDULED"
+        self.ups_instance.InputReadinessState = "READY"
+        self.ups_instance.ProcedureStepLabel = "Test UPS"
+        self.ups_instance.ScheduledProcedureStepStartDateTime = "20250101120000"
+        self.ups_instance.ScheduledProcedureStepPriority = "MEDIUM"
+
+    def tearDown(self):
+        # Remove and close the memory handler for the UPSPushNCreateSCU logger
+        self.scu_logger.removeHandler(self.memory_handler)
+        self.memory_handler.close()
+
+        # Remove and close the stream handler for the test logger
+        self.test_logger.removeHandler(self.stream_handler)
+        self.stream_handler.close()
+
+    @parameterized.expand(
+        [
+            ("success", "Success", 0, ""),
+        ]
+    )
+    def test_run_and_check_log(
+        self,
+        name,
+        expected_status_category,
+        expected_status_code,
+        expected_status_description,
+    ):
+        # Ensure the correct Python interpreter is used for the subprocess call
+        python_executable = sys.executable
+
+        # Start the UPS Push SCP CLI App upsscp.py
+        process = subprocess.Popen([python_executable, "tdwii_plus_examples/cli/upsscp/upsscp.py"])
+
+        # Check that the SCP is running
+        time.sleep(1)  # give some time for the SCP to start
+        self.assertEqual(self.upspush_ncreate_scu.verify().status_category, "Success")
+
+        # Run the test case
+        try:
+            success_count = self.upspush_ncreate_scu.create_ups_instances([self.ups_instance])
+
+            self.assertEqual(success_count, 1)
+
+            # Get the log messages
+            log_messages = [record.getMessage() for record in self.memory_handler.buffer]
+            self.test_logger.info("Log messages: %s", log_messages)
+
+        except Exception as e:
+            self.test_logger.error(e)
+            raise
+        finally:
+            # Terminate the UPS SCP CLI App subprocess
+            process.terminate()
+            process.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
@@ -101,7 +101,3 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_unit.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_unit.py
@@ -1,0 +1,98 @@
+import logging
+import unittest
+from unittest import mock
+
+from pydicom import Dataset
+from pydicom.uid import UID, generate_uid
+
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestUPSPushNCreateSCU(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Setup before all tests."""
+        # Create UPSPushNCreateSCU instance
+        cls.upspush_ncreate_scu = UPSPushNCreateSCU(
+            calling_ae_title="CALLING_AE_TITLE",
+            called_ae_title="CALLED_AE_TITLE",
+            called_ip="127.0.0.1",
+            called_port=11112,
+            logger=LOGGER,
+        )
+
+    @mock.patch("tdwii_plus_examples.upspushncreatescu.UPSPushNCreateSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspushncreatescu.UPSPushNCreateSCU._associate")
+    def test_create_ups_instances(self, mock_associate, mock_handle_response):
+        """Test creating multiple valid UPS instances."""
+        # Create 2 'valid' UPS instances
+        ds_1 = Dataset()
+        ds_1.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds_1.SOPInstanceUID = generate_uid()
+        ds_2 = Dataset()
+        ds_2.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds_2.SOPInstanceUID = generate_uid()
+        instances = [ds_1, ds_2]
+
+        # Mock the association instance.
+        mock_assoc_instance = mock.Mock()
+        # Mock the release method.
+        mock_assoc_instance.release = mock.Mock()
+        # Mock the send_n_create method to return a success status and an empty dataset.
+        mock_assoc_instance.send_n_create.return_value = (Dataset(), Dataset())
+        # Mock _associate to return the mock association instance, preventing a real association.
+        mock_associate.return_value = mock_assoc_instance
+        # Assign the mock association instance to the SCU's assoc attribute.
+        self.upspush_ncreate_scu.assoc = mock_assoc_instance
+        # Mock the _handle_response method to return a success status.
+        mock_handle_response.return_value = mock.Mock(status_category="Success")
+
+        # Call the method
+        success_count = self.upspush_ncreate_scu.create_ups_instances(instances)
+
+        # Assert 2 UPS N-CREATE messages were sent and succeeded
+        self.assertEqual(success_count, 2)
+        mock_assoc_instance.send_n_create.assert_called()
+        self.assertEqual(mock_assoc_instance.send_n_create.call_count, 2)
+
+    @mock.patch("tdwii_plus_examples.upspushncreatescu.Association")
+    def test_create_ups_instances_no_valid_instances(self, mock_assoc):
+        """Test creating UPS instances with no valid instances."""
+
+        # Create an invalid UPS instance
+        ds = Dataset()
+        ds.SOPClassUID = UID("1.2.3")  # Invalid SOP Class UID
+        instances = [ds]
+
+        # Call the method
+        success_count = self.upspush_ncreate_scu.create_ups_instances(instances)
+
+        # Assert UPS N-CREATE was not sent
+        self.assertEqual(success_count, 0)
+        mock_assoc.assert_not_called()
+
+    @mock.patch("tdwii_plus_examples.upspushncreatescu.UPSPushNCreateSCU._associate")
+    def test_create_ups_instances_association_failure(self, mock_associate):
+        """Test creating UPS instances with association failure."""
+        # Create 1 'valid' UPS instance
+        ds = Dataset()
+        ds.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds.SOPInstanceUID = generate_uid()
+        instances = [ds]
+
+        # Mock the association instance.
+        mock_assoc_instance = mock.Mock()
+        # Mock the release method.
+        mock_assoc_instance.release = mock.Mock()
+        # Mock _associate to return the mock association instance, preventing a real association.
+        mock_associate.return_value = mock_assoc_instance
+        # Set the status to "Error" to simulate an association failure.
+        mock_assoc_instance.status = "Error"
+
+        # Call the method
+        success_count = self.upspush_ncreate_scu.create_ups_instances(instances)
+
+        # Assert UPS creation failed
+        self.assertEqual(success_count, 0)

--- a/tdwii_plus_examples/upspushncreatescu.py
+++ b/tdwii_plus_examples/upspushncreatescu.py
@@ -15,11 +15,11 @@ class UPSPushNCreateSCU(BaseSCU):
     remote SCP.
 
     Attributes:
+        logger (logging.Logger): A logger instance.
         calling_ae_title (str): The title of the calling AE.
         called_ae_title (str): The title of the called AE.
         called_ip (str): The IP address or hostname of the called AE.
         called_port (int): The port number of the called AE.
-        logger (logging.Logger): A logger instance.
     """
 
     def __init__(
@@ -55,14 +55,14 @@ class UPSPushNCreateSCU(BaseSCU):
         Returns:
             int: The number of UPS instances successfully created.
         """
-        instances = [instance for instance in instances if instance.SOPClassUID == UnifiedProcedureStepPush]
+        valid_instances = [instance for instance in instances if instance.SOPClassUID == UnifiedProcedureStepPush]
         if not instances:
             self.logger.warning("No valid instances with SOPClassUID matching UnifiedProcedureStepPush.")
             return 0
-        if len(instances) < len(instances):
+        if len(valid_instances) < len(instances):
             self.logger.warning(
                 f"Some instances were ignored because their SOPClassUID did not match UnifiedProcedureStepPush. "
-                f"Total instances provided: {len(instances)}, valid instances: {len(instances)}"
+                f"Total instances provided: {len(instances)}, valid instances: {len(valid_instances)}"
             )
         assoc_result = self._associate()
         success_count = 0
@@ -83,7 +83,7 @@ class UPSPushNCreateSCU(BaseSCU):
 
         msg_id = 0
 
-        for instance in instances:
+        for instance in valid_instances:
             msg_id += 1
             result = self._send_upspushncreate_request(
                 assoc=self.assoc,

--- a/tdwii_plus_examples/upspushncreatescu.py
+++ b/tdwii_plus_examples/upspushncreatescu.py
@@ -1,0 +1,163 @@
+from pydicom import Dataset
+from pydicom.uid import UID
+from pynetdicom.association import Association
+from pynetdicom.sop_class import UnifiedProcedureStepPush
+
+from tdwii_plus_examples.basescu import BaseSCU
+
+
+class UPSPushNCreateSCU(BaseSCU):
+    """
+    A subclass of BaseSCU that implements the N-CREATE DIMSE operation
+    for the Unified Procedure Step Push SOP Class.
+
+    This class provides functionality for creating UPS instances on a
+    remote SCP.
+
+    Attributes:
+        calling_ae_title (str): The title of the calling AE.
+        called_ae_title (str): The title of the called AE.
+        called_ip (str): The IP address or hostname of the called AE.
+        called_port (int): The port number of the called AE.
+        logger (logging.Logger): A logger instance.
+    """
+
+    def __init__(
+        self,
+        logger=None,
+        calling_ae_title: str = None,
+        called_ip: str = None,
+        called_port: int = None,
+        called_ae_title: str = None,
+    ):
+        super().__init__(
+            logger,
+            calling_ae_title=calling_ae_title,
+            called_ip=called_ip,
+            called_port=called_port,
+            called_ae_title=called_ae_title,
+        )
+
+    def _add_requested_context(self):
+        """Add the Unified Procedure Step Push SOP Class presentation context."""
+        super()._add_requested_context()
+        self.ae.add_requested_context(UnifiedProcedureStepPush)
+        self.logger.debug(f"UPS Push Presentation context added: \n{self.ae.requested_contexts[0]}")
+
+    def create_ups_instances(self, instances: list[Dataset]) -> int:
+        """
+        Create UPS instances on the remote SCP.
+
+        Parameters:
+            instances (list[Dataset]): A list of DICOM datasets representing the UPS instances to create.
+            called_ae_title (str, optional): The AE title of the remote SCP. Defaults to None.
+
+        Returns:
+            int: The number of UPS instances successfully created.
+        """
+        instances = [instance for instance in instances if instance.SOPClassUID == UnifiedProcedureStepPush]
+        if not instances:
+            self.logger.warning("No valid instances with SOPClassUID matching UnifiedProcedureStepPush.")
+            return 0
+        if len(instances) < len(instances):
+            self.logger.warning(
+                f"Some instances were ignored because their SOPClassUID did not match UnifiedProcedureStepPush. "
+                f"Total instances provided: {len(instances)}, valid instances: {len(instances)}"
+            )
+        assoc_result = self._associate()
+        success_count = 0
+
+        if assoc_result.status == "Error":
+            result = self.PrimitiveResult("AssocFailure", 0xD000, assoc_result.description, None)
+            self.logger.error(f"Association failed: {result.status_description}")
+            return success_count
+
+        if assoc_result.status == "Warning":
+            accepted_sop_names = [f"[{UID(uid).name}]" for uid in assoc_result.accepted_sop_classes]
+            self.logger.warning(f"{assoc_result.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
+            if "[Unified Procedure Step - Watch SOP Class]" not in accepted_sop_names:
+                self.assoc.release()
+                result = self.PrimitiveResult("AssocFailure", 0xD001, assoc_result.description, None)
+                self.logger.error(f"Association failed: {result.status_description}")
+                return success_count
+
+        msg_id = 0
+
+        for instance in instances:
+            msg_id += 1
+            result = self._send_upspushncreate_request(
+                assoc=self.assoc,
+                attribute_list=instance,
+                class_uid=instance.SOPClassUID,
+                instance_uid=instance.SOPInstanceUID,
+                msg_id=msg_id,
+            )
+            if result.status_category == "Success":
+                success_count += 1
+            else:
+                self.logger.error(
+                    f"Failed to create UPS instance {instance.SOPInstanceUID}: "
+                    f"{result.status_description} (Status: {result.status_code})"
+                )
+
+        self.assoc.release()
+        self.logger.debug("Association released")
+
+        return success_count
+
+    def _send_upspushncreate_request(
+        self,
+        assoc: Association,
+        attribute_list: Dataset = None,
+        class_uid: UID = UnifiedProcedureStepPush,
+        instance_uid: UID = None,
+        msg_id: int = 1,
+    ) -> tuple:
+        """
+        Send an UPS Push N-CREATE request.
+
+        Parameters
+        ----------
+        assoc : Association
+            The Association object representing the established connection to the SCP.
+        attribute_list : pydicom.Dataset
+            The Attribute identifiers and values of the UPS Instance to create.
+        class_uid : pydicom.uid.UID
+            The SOP Class UID of the UPS Instance to create.
+        instance_uid: pydicom.uid.UID
+            The SOP Instance UID of the UPS Instance to create.
+        msg_id : int
+            The identifier of the request Message (default: 1).
+
+        Required attribute_list attributes are specified in PS3.4 Table CC.2.5-3
+        N-CREATE Usage column.
+
+        Returns
+        -------
+        PrimitiveResult:
+            A named tuple containing the status category, status code, status description, and dataset,
+            indicating the outcome of the request.
+
+        Valid status codes are specified in PS3.4 Table CC.2.5-4.
+        +----------------+-----------------------------------+-------------+
+        | Service Status | Further Meaning                   | Status Code |
+        +----------------+-----------------------------------+-------------+
+        | Success        | The UPS was created as requested  | 0000        |
+        +----------------+-----------------------------------+-------------+
+        | Warning        | The UPS was created with          | B300        |
+        |                | modifications                     |             |
+        +----------------+-----------------------------------+-------------+
+        | Failure        | Failed: The provided value of     | C309        |
+        |                | UPS State was not "SCHEDULED".    |             |
+        +----------------+-----------------------------------+-------------+
+        """
+        rsp_status = Dataset()
+        self.logger.debug("Sending N-CREATE request")
+        rsp_status, attribute_list = assoc.send_n_create(
+            dataset=attribute_list,
+            class_uid=class_uid,
+            instance_uid=instance_uid,
+            msg_id=msg_id,
+        )
+
+        return self._handle_response(rsp_status, attribute_list)


### PR DESCRIPTION
This merge request addresses part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It refactors ncreatescu.py from the tdwii_plus_examples/rtdbdi_creator folder.
The NCreateSCU class is refactored as UPSPushNCreateSCU and moved to tdwii_plus_examples package folder in upspushncreatescu.py.
UPSPushNCreateSCU is derived from a BaseSCU class.
The ncreatescu CLI application in tdwii_plus_examples package folder is also refactored and function is refactored as an upscreatescu.py CLI application and moved to the tdwii_plus_examples/cli folder.
Tests are provided.
Finally, the GUI application in tdwii_plus_examples/rtbdi_creator folder is refactored to use UPSPushNCreateSCU class.

## Summary by Sourcery

Refactor the NCreateSCU class into a more modular and reusable UPSPushNCreateSCU class, improving the DICOM UPS Push N-CREATE functionality across the project

New Features:
- Implement a new UPSPushNCreateSCU class that provides a more robust implementation of DICOM UPS Push N-CREATE operations
- Create a new CLI application for UPS Push N-CREATE operations with enhanced flexibility and logging

Enhancements:
- Modularize the DICOM UPS Push N-CREATE implementation
- Improve error handling and logging for UPS Push operations
- Add more comprehensive unit and integration tests for the UPS Push functionality

Tests:
- Add comprehensive unit tests for UPSPushNCreateSCU class
- Implement integration tests for UPS Push N-CREATE operations
- Create CLI application tests to verify different scenarios