### PR TITLE
Refactor storescu

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -614,6 +614,30 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
+    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
+    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
+    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
+    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
+    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+test = ["pytest", "pytest-xdist", "setuptools"]
+
+[[package]]
 name = "pycodestyle"
 version = "2.12.1"
 description = "Python style guide checker"
@@ -1286,4 +1310,4 @@ tests = ["dill", "flake8", "pylint", "pytest", "pytest-rerunfailures", "pytest-s
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "a4d39efc77c566ae9c404609ef5b026bbe077e4dc368ecb9e62dbd82817fee99"
+content-hash = "70e18e13af2a65bcc163d68f31a87f89a2e37561b5aee6ada147438c87d9fe54"

--- a/poetry.lock
+++ b/poetry.lock
@@ -441,6 +441,71 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.2.5"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "numpy-2.2.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1f4a922da1729f4c40932b2af4fe84909c7a6e167e6e99f71838ce3a29f3fe26"},
+    {file = "numpy-2.2.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6f91524d31b34f4a5fee24f5bc16dcd1491b668798b6d85585d836c1e633a6a"},
+    {file = "numpy-2.2.5-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:19f4718c9012e3baea91a7dba661dcab2451cda2550678dc30d53acb91a7290f"},
+    {file = "numpy-2.2.5-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:eb7fd5b184e5d277afa9ec0ad5e4eb562ecff541e7f60e69ee69c8d59e9aeaba"},
+    {file = "numpy-2.2.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6413d48a9be53e183eb06495d8e3b006ef8f87c324af68241bbe7a39e8ff54c3"},
+    {file = "numpy-2.2.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7451f92eddf8503c9b8aa4fe6aa7e87fd51a29c2cfc5f7dbd72efde6c65acf57"},
+    {file = "numpy-2.2.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0bcb1d057b7571334139129b7f941588f69ce7c4ed15a9d6162b2ea54ded700c"},
+    {file = "numpy-2.2.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36ab5b23915887543441efd0417e6a3baa08634308894316f446027611b53bf1"},
+    {file = "numpy-2.2.5-cp310-cp310-win32.whl", hash = "sha256:422cc684f17bc963da5f59a31530b3936f57c95a29743056ef7a7903a5dbdf88"},
+    {file = "numpy-2.2.5-cp310-cp310-win_amd64.whl", hash = "sha256:e4f0b035d9d0ed519c813ee23e0a733db81ec37d2e9503afbb6e54ccfdee0fa7"},
+    {file = "numpy-2.2.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c42365005c7a6c42436a54d28c43fe0e01ca11eb2ac3cefe796c25a5f98e5e9b"},
+    {file = "numpy-2.2.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:498815b96f67dc347e03b719ef49c772589fb74b8ee9ea2c37feae915ad6ebda"},
+    {file = "numpy-2.2.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:6411f744f7f20081b1b4e7112e0f4c9c5b08f94b9f086e6f0adf3645f85d3a4d"},
+    {file = "numpy-2.2.5-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:9de6832228f617c9ef45d948ec1cd8949c482238d68b2477e6f642c33a7b0a54"},
+    {file = "numpy-2.2.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:369e0d4647c17c9363244f3468f2227d557a74b6781cb62ce57cf3ef5cc7c610"},
+    {file = "numpy-2.2.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:262d23f383170f99cd9191a7c85b9a50970fe9069b2f8ab5d786eca8a675d60b"},
+    {file = "numpy-2.2.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:aa70fdbdc3b169d69e8c59e65c07a1c9351ceb438e627f0fdcd471015cd956be"},
+    {file = "numpy-2.2.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37e32e985f03c06206582a7323ef926b4e78bdaa6915095ef08070471865b906"},
+    {file = "numpy-2.2.5-cp311-cp311-win32.whl", hash = "sha256:f5045039100ed58fa817a6227a356240ea1b9a1bc141018864c306c1a16d4175"},
+    {file = "numpy-2.2.5-cp311-cp311-win_amd64.whl", hash = "sha256:b13f04968b46ad705f7c8a80122a42ae8f620536ea38cf4bdd374302926424dd"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ee461a4eaab4f165b68780a6a1af95fb23a29932be7569b9fab666c407969051"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ec31367fd6a255dc8de4772bd1658c3e926d8e860a0b6e922b615e532d320ddc"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:47834cde750d3c9f4e52c6ca28a7361859fcaf52695c7dc3cc1a720b8922683e"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2c1a1c6ccce4022383583a6ded7bbcda22fc635eb4eb1e0a053336425ed36dfa"},
+    {file = "numpy-2.2.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d75f338f5f79ee23548b03d801d28a505198297534f62416391857ea0479571"},
+    {file = "numpy-2.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a801fef99668f309b88640e28d261991bfad9617c27beda4a3aec4f217ea073"},
+    {file = "numpy-2.2.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:abe38cd8381245a7f49967a6010e77dbf3680bd3627c0fe4362dd693b404c7f8"},
+    {file = "numpy-2.2.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5a0ac90e46fdb5649ab6369d1ab6104bfe5854ab19b645bf5cda0127a13034ae"},
+    {file = "numpy-2.2.5-cp312-cp312-win32.whl", hash = "sha256:0cd48122a6b7eab8f06404805b1bd5856200e3ed6f8a1b9a194f9d9054631beb"},
+    {file = "numpy-2.2.5-cp312-cp312-win_amd64.whl", hash = "sha256:ced69262a8278547e63409b2653b372bf4baff0870c57efa76c5703fd6543282"},
+    {file = "numpy-2.2.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:059b51b658f4414fff78c6d7b1b4e18283ab5fa56d270ff212d5ba0c561846f4"},
+    {file = "numpy-2.2.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:47f9ed103af0bc63182609044b0490747e03bd20a67e391192dde119bf43d52f"},
+    {file = "numpy-2.2.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:261a1ef047751bb02f29dfe337230b5882b54521ca121fc7f62668133cb119c9"},
+    {file = "numpy-2.2.5-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4520caa3807c1ceb005d125a75e715567806fed67e315cea619d5ec6e75a4191"},
+    {file = "numpy-2.2.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d14b17b9be5f9c9301f43d2e2a4886a33b53f4e6fdf9ca2f4cc60aeeee76372"},
+    {file = "numpy-2.2.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ba321813a00e508d5421104464510cc962a6f791aa2fca1c97b1e65027da80d"},
+    {file = "numpy-2.2.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4cbdef3ddf777423060c6f81b5694bad2dc9675f110c4b2a60dc0181543fac7"},
+    {file = "numpy-2.2.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54088a5a147ab71a8e7fdfd8c3601972751ded0739c6b696ad9cb0343e21ab73"},
+    {file = "numpy-2.2.5-cp313-cp313-win32.whl", hash = "sha256:c8b82a55ef86a2d8e81b63da85e55f5537d2157165be1cb2ce7cfa57b6aef38b"},
+    {file = "numpy-2.2.5-cp313-cp313-win_amd64.whl", hash = "sha256:d8882a829fd779f0f43998e931c466802a77ca1ee0fe25a3abe50278616b1471"},
+    {file = "numpy-2.2.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e8b025c351b9f0e8b5436cf28a07fa4ac0204d67b38f01433ac7f9b870fa38c6"},
+    {file = "numpy-2.2.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8dfa94b6a4374e7851bbb6f35e6ded2120b752b063e6acdd3157e4d2bb922eba"},
+    {file = "numpy-2.2.5-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:97c8425d4e26437e65e1d189d22dff4a079b747ff9c2788057bfb8114ce1e133"},
+    {file = "numpy-2.2.5-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:352d330048c055ea6db701130abc48a21bec690a8d38f8284e00fab256dc1376"},
+    {file = "numpy-2.2.5-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b4c0773b6ada798f51f0f8e30c054d32304ccc6e9c5d93d46cb26f3d385ab19"},
+    {file = "numpy-2.2.5-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55f09e00d4dccd76b179c0f18a44f041e5332fd0e022886ba1c0bbf3ea4a18d0"},
+    {file = "numpy-2.2.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:02f226baeefa68f7d579e213d0f3493496397d8f1cff5e2b222af274c86a552a"},
+    {file = "numpy-2.2.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c26843fd58f65da9491165072da2cccc372530681de481ef670dcc8e27cfb066"},
+    {file = "numpy-2.2.5-cp313-cp313t-win32.whl", hash = "sha256:1a161c2c79ab30fe4501d5a2bbfe8b162490757cf90b7f05be8b80bc02f7bb8e"},
+    {file = "numpy-2.2.5-cp313-cp313t-win_amd64.whl", hash = "sha256:d403c84991b5ad291d3809bace5e85f4bbf44a04bdc9a88ed2bb1807b3360bb8"},
+    {file = "numpy-2.2.5-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b4ea7e1cff6784e58fe281ce7e7f05036b3e1c89c6f922a6bfbc0a7e8768adbe"},
+    {file = "numpy-2.2.5-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:d7543263084a85fbc09c704b515395398d31d6395518446237eac219eab9e55e"},
+    {file = "numpy-2.2.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0255732338c4fdd00996c0421884ea8a3651eea555c3a56b84892b66f696eb70"},
+    {file = "numpy-2.2.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d2e3bdadaba0e040d1e7ab39db73e0afe2c74ae277f5614dad53eadbecbbb169"},
+    {file = "numpy-2.2.5.tar.gz", hash = "sha256:a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
@@ -1221,4 +1286,4 @@ tests = ["dill", "flake8", "pylint", "pytest", "pytest-rerunfailures", "pytest-s
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "51323e89a37aa73a7ce0e15d4f1937731b066d930baddf63aa6940dd34d80206"
+content-hash = "a4d39efc77c566ae9c404609ef5b026bbe077e4dc368ecb9e62dbd82817fee99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ parameterized = "^0.9.0"
 isort = { version = "*", optional = true}            # groups = ["dev", "tests", "all"]
 ruff = { version = "*", optional = true}             # groups = ["dev", "tests", "all"]
 numpy = "^2.2.5"
+psutil = "^7.0.0"
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ update = "^0.0.1"
 parameterized = "^0.9.0"
 isort = { version = "*", optional = true}            # groups = ["dev", "tests", "all"]
 ruff = { version = "*", optional = true}             # groups = ["dev", "tests", "all"]
+numpy = "^2.2.5"
 
 
 

--- a/tdwii_plus_examples/cli/storescu.py
+++ b/tdwii_plus_examples/cli/storescu.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""
+A DICOM Storage Service Class Provider (SCU) application.
+
+This application implements Storage SOP Class SCU.
+It uses the DIMSE C-STORE Service to store SOP instances on a remote SCP.
+
+Usage:
+    storescu [options] ip port path
+
+Arguments:
+    ip    IP address of called AE
+    port  TCP port number of called AE
+    path  DICOM file or directory containing SOP instances to store
+
+Options:
+    -h, --help               Show this help message and exit
+    -aet, --ae_title         Application Entity Title (default: UPSPUSHSCU)
+    -aec, --called_ae_title  Called Application Entity Title (default: ANYSCP)
+    -e, --echo               Verification of DICOM connection with Called AET
+    -v, --verbose            Set log level to INFO
+    -d, --debug              Set log level to DEBUG
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from pydicom import dcmread
+from pynetdicom.apps.common import get_files
+
+from tdwii_plus_examples.cstorescu import CStoreSCU
+
+
+def get_contexts(fpaths, app_logger):
+    """Return the valid DICOM files and their Presentation Context.
+
+    Parameters
+    ----------
+    fpaths : list of str
+        A list of paths to the files to try and get data from.
+
+    Returns
+    -------
+    list of str, dict
+        A list of paths to valid DICOM files and the {SOP Class UID :
+        [Transfer Syntax UIDs]} that can be used to create the required
+        presentation contexts.
+    """
+    good, bad = [], []
+    contexts = {}
+    for fpath in fpaths:
+        path = os.fspath(Path(fpath).resolve())
+        try:
+            ds = dcmread(path)
+        except Exception:
+            bad.append(("Bad DICOM file", path))
+            continue
+
+        try:
+            sop_class = ds.SOPClassUID
+            tsyntax = ds.file_meta.TransferSyntaxUID
+        except Exception:
+            bad.append(("Unknown SOP Class or Transfer Syntax UID", path))
+            continue
+
+        tsyntaxes = contexts.setdefault(sop_class, [])
+        if tsyntax not in tsyntaxes:
+            tsyntaxes.append(tsyntax)
+
+        good.append(path)
+
+    for reason, path in bad:
+        app_logger.error(f"{reason}: {path}")
+
+    return good, contexts
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a DICOM SOP Instance C-STORE request")
+    parser.add_argument("ip", type=str, help="IP address or hotname of called AE")
+    parser.add_argument("port", type=int, help="TCP port number of called AE")
+    parser.add_argument(
+        "path", metavar="path", nargs="+", help="DICOM file or directory containing SOP instances to store", type=str
+    )
+    parser.add_argument("-r", "--recurse", help="recursively search the given directory", action="store_true")
+    parser.add_argument("-aet", "--ae_title", type=str, default="STOREZSCU", help="Application Entity Title")
+    parser.add_argument("-aec", "--called_ae_title", type=str, default="ANYSCP", help="Called Application Entity Title")
+    parser.add_argument("-e", "--echo", action="store_true", help="Verification of DICOM connection with Called AET")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Set log level to INFO")
+    parser.add_argument("-d", "--debug", action="store_true", help="Set log level to DEBUG")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
+
+    args = parser.parse_args()
+
+    if args.quiet:
+        log_level = logging.CRITICAL
+    elif args.verbose:
+        log_level = logging.INFO
+    elif args.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.WARNING
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger("storescu")
+    logger.setLevel(log_level)
+
+    logger.info(f"Initializing CStoreSCU instance with remote SCP {args.called_ae_title}@{args.ip}:{args.port}")
+    scu = CStoreSCU(
+        logger=logger,
+        calling_ae_title=args.ae_title,
+        called_ip=args.ip,
+        called_port=args.port,
+        called_ae_title=args.called_ae_title,
+        contexts=None,
+    )
+
+    # Verification requested
+    if args.echo:
+        print("Verification (C-ECHO) request")
+        num_created_instances = scu.verify()
+        if num_created_instances.status_category == "Success":
+            print("Verification (C-ECHO) successful")
+        else:
+            print(f"Verification (C-ECHO) failed: {num_created_instances.status_description}")
+
+    # UPS instances creation requested
+    elif args.path is not None:
+        valid_paths, invalid_paths = get_files(args.path, args.recurse)
+
+        for path in invalid_paths:
+            logger.error(f"Cannot access path: {path}")
+
+        dicom_file_paths, contexts = get_contexts(valid_paths, logger)
+
+        if not dicom_file_paths:
+            logger.warning("No suitable DICOM files found")
+            sys.exit()
+
+        print(contexts)
+        scu.set_contexts(contexts)
+        instances = []
+        for dicom_file_path in dicom_file_paths:
+            logger.info(f"Sending file: {dicom_file_path}")
+            try:
+                ds = dcmread(dicom_file_path)  # do not set force flag to require DICOM Part 10 files
+                instances.append(ds)
+            except Exception as e:
+                logger.error(f"Failed to read DICOM file {dicom_file_path}: {e}")
+                continue
+
+        num_created_instances = scu.store_instances(instances)
+
+        if num_created_instances == len(dicom_file_paths):
+            print("Storage successful")
+        elif num_created_instances > 0:
+            print("Some SOP instances storage failed")
+        else:
+            print("Storage failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tdwii_plus_examples/cli/storescu.py
+++ b/tdwii_plus_examples/cli/storescu.py
@@ -86,7 +86,7 @@ def main():
         "path", metavar="path", nargs="+", help="DICOM file or directory containing SOP instances to store", type=str
     )
     parser.add_argument("-r", "--recurse", help="recursively search the given directory", action="store_true")
-    parser.add_argument("-aet", "--ae_title", type=str, default="STOREZSCU", help="Application Entity Title")
+    parser.add_argument("-aet", "--ae_title", type=str, default="STORESCU", help="Application Entity Title")
     parser.add_argument("-aec", "--called_ae_title", type=str, default="ANYSCP", help="Called Application Entity Title")
     parser.add_argument("-e", "--echo", action="store_true", help="Verification of DICOM connection with Called AET")
     parser.add_argument("-v", "--verbose", action="store_true", help="Set log level to INFO")

--- a/tdwii_plus_examples/cstorescu.py
+++ b/tdwii_plus_examples/cstorescu.py
@@ -1,0 +1,232 @@
+from pydicom import Dataset
+from pydicom.uid import UID, ExplicitVRLittleEndian
+from pynetdicom.association import Association
+from pynetdicom.presentation import PresentationContext, StoragePresentationContexts, build_context
+from pynetdicom.status import STORAGE_SERVICE_CLASS_STATUS
+
+from tdwii_plus_examples.basescu import BaseSCU
+
+# List of storage SOP Classes
+storage_sop_classes = [cx.abstract_syntax for cx in StoragePresentationContexts]
+
+
+class CStoreSCU(BaseSCU):
+    """
+    A subclass of BaseSCU that implements the C-STORE DIMSE operation
+    for specified Storage SOP Classes.
+
+    This class provides functionality for storage of SOP instances on a
+    remote SCP.
+
+    Attributes:
+        logger (logging.Logger): A logger instance.
+        calling_ae_title (str): The title of the calling AE.
+        called_ae_title (str): The title of the called AE.
+        called_ip (str): The IP address or hostname of the called AE.
+        called_port (int): The port number of the called AE.
+        contexts (list[PresentationContext]): The Storage Presentation
+            Contexts to use for C-STORE operations
+    """
+
+    def __init__(
+        self,
+        logger=None,
+        calling_ae_title: str = None,
+        called_ip: str = None,
+        called_port: int = None,
+        called_ae_title: str = None,
+        contexts: PresentationContext = None,
+    ):
+        self.contexts = self._validate_contexts(contexts)
+        super().__init__(
+            logger,
+            calling_ae_title=calling_ae_title,
+            called_ip=called_ip,
+            called_port=called_port,
+            called_ae_title=called_ae_title,
+        )
+
+    def _add_requested_context(self):
+        """
+        Adds the storage presentation contexts specified in the constructor.
+
+        This method is called by the `BaseSCU` constructor. It adds the
+        necessary presentation contexts for the storage operations.
+        """
+        # Add Verification context from BaseSCU
+        super()._add_requested_context()
+        # Add Storage contexts
+        if self.contexts:
+            for context in self.contexts:
+                self.ae.add_requested_context(context.abstract_syntax, context.transfer_syntax[0])
+                self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
+
+    def set_contexts(self, contexts: list[PresentationContext]):
+        for context in contexts:
+            self.ae.add_requested_context(context.abstract_syntax, context.transfer_syntax[0])
+            self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
+        self.contexts = self.contexts.append(contexts)
+
+    def set_contexts_from_files(self, instances: list[Dataset]):
+        """
+        Adds storage presentation contexts from a list of DICOM datasets.
+
+        This method determines the SOP Class UID from each dataset and adds
+        a corresponding presentation context using ExplicitVRLittleEndian transfer
+        syntax.
+
+        Args:
+            instances (list[Dataset]): A list of DICOM datasets.
+        """
+        # Favouring ExplicitLittleEndian to avoid issues with QRSCP when there are private elements
+        # There is a catch-22 if you have privates *and* a string type element with length > 64K
+        # For RT SS with way too much data in the contours or RT Ion Plan with compensator voxel thickness with
+        # a large number of rows and columns... some of the elements can exceed 64K and then the explicit syntax
+        # doesn't have room in the 16 bit unsigned integer for lengths (in bytes) > 64k
+        contexts_in_files = [
+            build_context(instance.SOPClassUID, transfer_syntax=[ExplicitVRLittleEndian]) for instance in instances
+        ]
+        for abstract_syntax, transfer_syntaxes in contexts_in_files.items():
+            self.ae.add_requested_context(abstract_syntax, transfer_syntaxes[0])
+            self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
+        self.contexts = self.contexts.append(contexts_in_files)
+
+    def store_instances(self, instances: list[Dataset]) -> int:
+        """
+        Stores DICOM instances on the remote SCP.
+
+        Parameters:
+            instances (list[Dataset]): A list of DICOM datasets representing the DICOM instances to store.
+            called_ae_title (str, optional): The AE title of the remote SCP. Defaults to None.
+
+        Returns:
+            int: The number of DICOM instances successfully stored.
+        """
+        assoc_result = self._associate()
+        success_count = 0
+
+        if not self._handle_association_status(assoc_result):
+            return 0
+
+        for msg_id, instance in enumerate(instances, start=0):
+            result = self._send_cstore_request(
+                assoc=self.assoc,
+                dataset=instance,
+                msg_id=msg_id,
+            )
+            if result.status_category == "Success":
+                success_count += 1
+            else:
+                self.logger.error(
+                    f"Failed to create UPS instance {instance.SOPInstanceUID}: "
+                    f"{result.status_description} (Status: {result.status_code})"
+                )
+
+        self.assoc.release()
+        self.logger.debug("Association released")
+
+        return success_count
+
+    def _validate_contexts(self, contexts):
+        """Validates that all provided contexts are Storage SOP Classes.
+
+        Args:
+            contexts: A list of PresentationContext objects.
+
+        Returns:
+            The validated list of contexts if all are storage contexts, otherwise raises a ValueError.
+
+        Raises:
+            ValueError: If any of the provided contexts is not a Storage SOP Class.
+        """
+        if not contexts:
+            return []
+        invalid_contexts = [
+            context for context in contexts if not self.is_storage_presentation_context(context.abstract_syntax)
+        ]
+        if invalid_contexts:
+            error_message = (
+                "Only Storage Presentation Contexts are allowed. "
+                f"Invalid contexts: {[ctx.abstract_syntax for ctx in invalid_contexts]}"
+            )
+            raise ValueError(error_message)
+        return contexts
+
+    def is_storage_presentation_context(self, context):
+        return context in storage_sop_classes
+
+    def _handle_association_status(self, assoc_result) -> bool:
+        """Handles the association status returned by the SCP.
+
+        Handles the association result and verifies that all requested
+        presentation contexts have been accepted.
+
+        Args:
+            assoc_result: The result of the association request.
+
+        Returns:
+            True if the association was successful and all requested presentation
+            contexts were accepted, False otherwise.
+        """
+        if assoc_result.status == "Error":
+            self.logger.error(f"Association failed: {assoc_result.description}")
+            return False
+        if assoc_result.status == "Warning":
+            accepted_contexts = {UID(uid): 0x00 for uid in assoc_result.accepted_sop_classes}
+            if any(accepted_contexts.get(context.abstract_syntax) != 0x00 for context in self.contexts):
+                not_accepted = [
+                    str(context.abstract_syntax)
+                    for context in self.contexts
+                    if accepted_contexts.get(context.abstract_syntax) != 0x00
+                ]
+                self.logger.warning(f"{assoc_result.description} - Not Accepted SOP Classes: {', '.join(not_accepted)}")
+                self.assoc.release()
+                self.logger.error("Association failed: Not all required presentation contexts were accepted.")
+                return False
+        return True
+
+    def _send_cstore_request(self, assoc: Association, dataset: Dataset, msg_id: int = 1) -> tuple:
+        """
+        Send an C-STORE request.
+
+        Parameters
+        ----------
+        assoc : Association
+            The Association object representing the established connection to the SCP.
+        dataset : pydicom.Dataset
+            The Attributes of the Composite SOP Instance to be stored.
+        msg_id : int
+            The identifier of the request Message (default: 1).
+
+        Returns
+        -------
+        PrimitiveResult:
+            A named tuple containing the status category, status code, status description, and dataset,
+            indicating the outcome of the request.
+
+        Valid status codes are specified in PS3.7 Section 9.1.1.1.9 Status.
+        """
+        rsp_status = Dataset()
+        self.logger.debug("Sending C-STORE request")
+        rsp_status = assoc.send_c_store(
+            dataset=dataset,
+            msg_id=msg_id,
+        )
+
+        return self._handle_response(rsp_status, None)
+
+    def _get_status_description(self, status_code):
+        """Retrieves the description for a given status code.
+
+        Checks storage service specific status codes, then general status codes.
+
+        Args:
+            status_code: The status code to look up.
+
+        Returns:
+            str: The description part of the status code, or "Unknown" if not found.
+        """
+        description = STORAGE_SERVICE_CLASS_STATUS.get(status_code, None)
+        if description is None:
+            description = super()._get_status_description(status_code)
+        return description[1]

--- a/tdwii_plus_examples/cstorescu.py
+++ b/tdwii_plus_examples/cstorescu.py
@@ -62,14 +62,16 @@ class CStoreSCU(BaseSCU):
                 self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
 
     def set_contexts(self, contexts: list[PresentationContext]):
-        for context in contexts:
-            self.ae.add_requested_context(context.abstract_syntax, context.transfer_syntax[0])
-            self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
-        self.contexts = self.contexts.append(contexts)
+        """Overrides the storage presentation contexts"""
+        # Remove all existing presentation contexts
+        self.ae.requested_contexts = []
+        self.contexts = self._validate_contexts(contexts)
+        self._add_requested_context()
 
     def set_contexts_from_files(self, instances: list[Dataset]):
         """
-        Adds storage presentation contexts from a list of DICOM datasets.
+        Overrides the storage presentation contexts with the contexts from a list
+        of DICOM datasets.
 
         This method determines the SOP Class UID from each dataset and adds
         a corresponding presentation context using ExplicitVRLittleEndian transfer
@@ -86,10 +88,7 @@ class CStoreSCU(BaseSCU):
         contexts_in_files = [
             build_context(instance.SOPClassUID, transfer_syntax=[ExplicitVRLittleEndian]) for instance in instances
         ]
-        for abstract_syntax, transfer_syntaxes in contexts_in_files.items():
-            self.ae.add_requested_context(abstract_syntax, transfer_syntaxes[0])
-            self.logger.debug(f"Storage Presentation contexts added: \n{self.ae.requested_contexts[1:]}")
-        self.contexts = self.contexts.append(contexts_in_files)
+        self.set_contexts(contexts_in_files)
 
     def store_instances(self, instances: list[Dataset]) -> int:
         """

--- a/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
+++ b/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
@@ -114,8 +114,9 @@ class MainBDIWidget(QWidget):
     @Slot()
     def _store_plan_button_clicked(self):
         dest_ae_title = self.ui.line_edit_move_scp_ae_title.text()
-        ip_addr = self.known_ae_ipaddr.get(dest_ae_title)
-        port = self.known_ae_port.get(dest_ae_title)
+        ip_addr, port = self._get_ae_config(dest_ae_title)
+        if ip_addr is None or port is None:
+            return
         store_scu = CStoreSCU(
             calling_ae_title=self.ae_title, called_ae_title=dest_ae_title, called_ip=ip_addr, called_port=port
         )
@@ -166,8 +167,10 @@ class MainBDIWidget(QWidget):
         self.export_path = bdi_path
 
         dest_ae_title = self.ui.line_edit_move_scp_ae_title.text()
-        ip_addr = self.known_ae_ipaddr.get(dest_ae_title)
-        port = self.known_ae_port.get(dest_ae_title)
+        ip_addr, port = self._get_ae_config(dest_ae_title)
+        if ip_addr is None or port is None:
+            return
+
         store_scu = CStoreSCU(
             calling_ae_title=self.ae_title, called_ae_title=dest_ae_title, called_ip=ip_addr, called_port=port
         )
@@ -175,6 +178,15 @@ class MainBDIWidget(QWidget):
         store_scu.set_contexts_from_files(iods)
         success = store_scu.store_instances(instances=iods)
         self._command_outcome_message(success=success, command_name="C-STORE")
+
+    def _get_ae_config(self, ae_title):
+        """Retrieves AE configuration (IP and port).  Logs an error and returns None if config is missing."""
+        ip_addr = self.known_ae_ipaddr.get(ae_title)
+        port = self.known_ae_port.get(ae_title)
+        if ip_addr is None or port is None:
+            self.logger.error(f"Missing configuration for AE title: {ae_title}")
+            return None, None  # Return None for both if config is missing
+        return ip_addr, port
 
     @Slot()
     def _export_ups_button_clicked(self):

--- a/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
+++ b/tdwii_plus_examples/rtbdi_creator/mainbdiwidget.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 )
 
 from tdwii_plus_examples import tdwii_config
+from tdwii_plus_examples.cstorescu import CStoreSCU
 from tdwii_plus_examples.rtbdi_creator.rtbdi_factory import (
     create_rtbdi_from_rtion_plan,
     create_ups_from_plan_and_bdi,
@@ -26,7 +27,6 @@ from tdwii_plus_examples.rtbdi_creator.rtbdi_factory import (
     write_rtbdi,
     write_ups,
 )
-from tdwii_plus_examples.rtbdi_creator.storescu import StoreSCU
 
 # Important:
 # You need to run the following command to generate the ui_form.py file
@@ -69,11 +69,14 @@ class MainBDIWidget(QWidget):
         self.fraction_number = 1
         self.retrieve_ae_title = ""
         self.scheduled_datetime = datetime.now
-        self.ae_title = "TMS"  # as an SCU... maybe should use a different AE Title?
-        config_file = "rtbdi.toml"
-        # TODO: command line argument specifying a different config file
+        self.ae_title = "TMS"
+        self.config_file = "rtbdi.toml"
+        self._load_ae_config()
+
+    def _load_ae_config(self):
+        """Loads AE configuration from the TOML and JSON files."""
         try:
-            with open(config_file, "rb") as f:
+            with open(self.config_file, "rb") as f:
                 toml_dict = tomli.load(f)
             if "DEFAULT" in toml_dict:
                 default_dict = toml_dict["DEFAULT"]
@@ -88,9 +91,12 @@ class MainBDIWidget(QWidget):
                     self.plan_path = str(Path(default_dict["plan_path"]).expanduser())
                 if "ups_scp_ae_title" in default_dict:
                     self.ui.line_edit_tms_scp_ae_title.setText(default_dict["ups_scp_ae_title"])
-
             else:
                 self.logger.warning("No [DEFAULT] section in toml config file")
+
+            tdwii_config.load_ae_config()
+            self.known_ae_ipaddr = tdwii_config.known_ae_ipaddr
+            self.known_ae_port = tdwii_config.known_ae_port
 
         except OSError as config_file_error:
             self.logger.exception("Problem parsing config file: " + config_file_error)
@@ -107,14 +113,20 @@ class MainBDIWidget(QWidget):
 
     @Slot()
     def _store_plan_button_clicked(self):
-        store_scu = StoreSCU(self.ae_title, self.ui.line_edit_move_scp_ae_title.text())
+        dest_ae_title = self.ui.line_edit_move_scp_ae_title.text()
+        ip_addr = self.known_ae_ipaddr.get(dest_ae_title)
+        port = self.known_ae_port.get(dest_ae_title)
+        store_scu = CStoreSCU(
+            calling_ae_title=self.ae_title, called_ae_title=dest_ae_title, called_ip=ip_addr, called_port=port
+        )
         # always re-load.  Not performant, but safe choice.
         # a more performant approach would be to force a re-load every time a plan is selected.
         # that's not really necessary unless the plan has to be (C-)stored
         plan = load_plan(self.ui.lineedit_plan_selector.text())
         iods = list()
         iods.append(plan)
-        success = store_scu.store(iods=iods)
+        store_scu.set_contexts_from_files(iods)
+        success = store_scu.store_instances(instances=iods)
         self._command_outcome_message(success=success, command_name="C-STORE")
 
         return
@@ -153,9 +165,15 @@ class MainBDIWidget(QWidget):
         write_rtbdi(rtbdi, bdi_path)
         self.export_path = bdi_path
 
-        store_scu = StoreSCU(self.ae_title, self.ui.line_edit_move_scp_ae_title.text())
+        dest_ae_title = self.ui.line_edit_move_scp_ae_title.text()
+        ip_addr = self.known_ae_ipaddr.get(dest_ae_title)
+        port = self.known_ae_port.get(dest_ae_title)
+        store_scu = CStoreSCU(
+            calling_ae_title=self.ae_title, called_ae_title=dest_ae_title, called_ip=ip_addr, called_port=port
+        )
         iods = [rtbdi]
-        success = store_scu.store(iods=iods)
+        store_scu.set_contexts_from_files(iods)
+        success = store_scu.store_instances(instances=iods)
         self._command_outcome_message(success=success, command_name="C-STORE")
 
     @Slot()
@@ -184,9 +202,11 @@ class MainBDIWidget(QWidget):
             self.logger.warning("No TMS AE Title specified, will not attempt an N-CREATE")
         else:
             dest_ae_title = tms_ae_title.strip()
-            tdwii_config.load_ae_config()
-            ip_addr = tdwii_config.known_ae_ipaddr[dest_ae_title]
-            port = tdwii_config.known_ae_port[dest_ae_title]
+            ip_addr = self.known_ae_ipaddr.get(dest_ae_title)
+            port = self.known_ae_port.get(dest_ae_title)
+            if ip_addr is None or port is None:
+                self.logger.error(f"AE title '{dest_ae_title}' not found in configuration.")
+                return
             ncreate_scu = UPSPushNCreateSCU(
                 logger=self.logger,
                 calling_ae_title=self.ae_title,

--- a/tdwii_plus_examples/tests/cli/test_storescu.py
+++ b/tdwii_plus_examples/tests/cli/test_storescu.py
@@ -23,6 +23,21 @@ class TestStoreSCU(unittest.TestCase):
         mock_scu_instance.verify.assert_called_once()
 
     @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
+    @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path", "-e"])
+    def test_echo_failure(self, mock_scu):
+        """Test Verification option (C-ECHO) failure path."""
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.verify.return_value.status_category = "Failure"
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+            output = mock_stdout.getvalue()
+
+        self.assertIn("Verification (C-ECHO) failed", output)
+        mock_scu_instance.verify.assert_called_once()
+
+    @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
     @patch("tdwii_plus_examples.cli.storescu.get_files")
     @patch("tdwii_plus_examples.cli.storescu.get_contexts")
     @patch("tdwii_plus_examples.cli.storescu.dcmread")

--- a/tdwii_plus_examples/tests/cli/test_storescu.py
+++ b/tdwii_plus_examples/tests/cli/test_storescu.py
@@ -1,0 +1,91 @@
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+# Import the main function from storescu.py
+from tdwii_plus_examples.cli.storescu import main
+
+
+class TestStoreSCU(unittest.TestCase):
+    @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
+    @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path", "-e"])
+    def test_echo_success(self, mock_scu):
+        """Test Verification option (C-ECHO)."""
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.verify.return_value.status_category = "Success"
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+            output = mock_stdout.getvalue()
+
+        self.assertIn("Verification (C-ECHO) successful", output)
+        mock_scu_instance.verify.assert_called_once()
+
+    @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
+    @patch("tdwii_plus_examples.cli.storescu.get_files")
+    @patch("tdwii_plus_examples.cli.storescu.dcmread")
+    @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path"])
+    def test_store_instances(self, mock_dcmread, mock_get_files, mock_scu):
+        """Test storing SOP instances."""
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.store_instances.return_value = 1  # Return an integer
+
+        # Mock get_files to return one valid file and one invalid file
+        mock_get_files.return_value = (["valid_file.dcm"], ["invalid_file.dcm"])
+
+        # Mock dcmread to return a valid dataset for the valid file
+        mock_dcmread.return_value = MagicMock()
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+            output = mock_stdout.getvalue()
+
+        # Assert that the success message is printed
+        self.assertIn("Storage successful", output)
+
+        # Assert that store_instances is called once
+        mock_scu_instance.store_instances.assert_called_once()
+
+    @patch("tdwii_plus_examples.cli.storescu.get_files")
+    @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path"])
+    def test_no_valid_files(self, mock_get_files):
+        """Test error case where no valid DICOM files are found."""
+        mock_get_files.return_value = ([], ["invalid_file.dcm"])
+
+        with self.assertLogs("storescu", level="WARNING") as log:
+            with self.assertRaises(SystemExit):
+                main()
+
+        # Assert that the warning message is in the logs
+        self.assertIn("No suitable DICOM files found", log.output[-1])
+
+    @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
+    @patch("tdwii_plus_examples.cli.storescu.get_contexts")
+    @patch("tdwii_plus_examples.cli.storescu.get_files")
+    @patch("tdwii_plus_examples.cli.storescu.dcmread")
+    @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path"])
+    def test_failed_dcmread(self, mock_dcmread, mock_get_files, mock_get_contexts, mock_scu):
+        """Test error case where dcmread fails."""
+        # Mock get_files to return one valid file
+        mock_get_files.return_value = (["valid_file.dcm"], [])
+
+        # Mock dcmread to raise an exception for the valid file
+        mock_dcmread.side_effect = Exception("Failed to read file")
+
+        mock_scu_instance = MagicMock()
+        mock_scu.return_value = mock_scu_instance
+        mock_scu_instance.store_instances.return_value = 1  # Return an integer
+
+        mock_get_contexts.return_value = ["valid_file.dcm"], []
+
+        with self.assertLogs("storescu", level="ERROR") as log:
+            main()
+
+        # Assert that the error message is in the logs
+        self.assertIn("Failed to read DICOM file valid_file.dcm", log.output[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/cli/test_storescu.py
+++ b/tdwii_plus_examples/tests/cli/test_storescu.py
@@ -24,16 +24,20 @@ class TestStoreSCU(unittest.TestCase):
 
     @patch("tdwii_plus_examples.cli.storescu.CStoreSCU")
     @patch("tdwii_plus_examples.cli.storescu.get_files")
+    @patch("tdwii_plus_examples.cli.storescu.get_contexts")
     @patch("tdwii_plus_examples.cli.storescu.dcmread")
     @patch("sys.argv", new=["storescu.py", "127.0.0.1", "11112", "test_path"])
-    def test_store_instances(self, mock_dcmread, mock_get_files, mock_scu):
+    def test_store_instances(self, mock_dcmread, mock_get_contexts, mock_get_files, mock_scu):
         """Test storing SOP instances."""
         mock_scu_instance = MagicMock()
         mock_scu.return_value = mock_scu_instance
         mock_scu_instance.store_instances.return_value = 1  # Return an integer
 
-        # Mock get_files to return one valid file and one invalid file
+        # Mock get_files to return one valid file path and one invalid file path
         mock_get_files.return_value = (["valid_file.dcm"], ["invalid_file.dcm"])
+
+        # Mock get_contexts to return one valid file and a valid context dict
+        mock_get_contexts.return_value = (["valid_file.dcm"], {"1.2.840.10008.5.1.4.1.1.4": ["1.2.840.10008.1.2.1"]})
 
         # Mock dcmread to return a valid dataset for the valid file
         mock_dcmread.return_value = MagicMock()
@@ -78,7 +82,7 @@ class TestStoreSCU(unittest.TestCase):
         mock_scu.return_value = mock_scu_instance
         mock_scu_instance.store_instances.return_value = 1  # Return an integer
 
-        mock_get_contexts.return_value = ["valid_file.dcm"], []
+        mock_get_contexts.return_value = (["valid_file.dcm"], {"1.2.840.10008.5.1.4.1.1.4": ["1.2.840.10008.1.2.1"]})
 
         with self.assertLogs("storescu", level="ERROR") as log:
             main()

--- a/tdwii_plus_examples/tests/test_cstorescu_integration.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_integration.py
@@ -1,0 +1,112 @@
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+from logging.handlers import MemoryHandler
+
+from parameterized import parameterized
+from pydicom.uid import ExplicitVRLittleEndian
+from pynetdicom.presentation import build_context
+from pynetdicom.sop_class import _STORAGE_CLASSES
+
+from tdwii_plus_examples.cstorescu import CStoreSCU
+from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_sc_images
+from tdwii_plus_examples.tests.utils.utils import get_configured_logger, start_scp
+
+
+class TestCStoreSCU(unittest.TestCase):
+    def setUp(self):
+        # Set up the logger for the CStoreSCU to INFO level
+        # with a memory handler to store up to 100 log messages
+        self.scu_logger, self.memory_handler = get_configured_logger(
+            "cstorescu", level=logging.WARNING, handler_class=MemoryHandler, capacity=100
+        )
+
+        # Set up the logger for this test to INFO level
+        # with a stream handler to print the log messages to the console
+        self.test_logger, self.stream_handler = get_configured_logger("test_cstorescu")
+
+        # Create 3 10x10 SC Image instances for testing
+        self.sc_images = generate_sc_images(3, 10, 10)
+
+        # Create a temporary directory
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_logger.info(f"{self.temp_dir} directory created")
+
+        # Create a UPSPushNCreateSCU instance
+        required_contexts = [
+            build_context(sop_class_uid, ExplicitVRLittleEndian)
+            for sop_class_uid in [
+                _STORAGE_CLASSES["SecondaryCaptureImageStorage"],
+                _STORAGE_CLASSES["CTImageStorage"],
+            ]
+        ]
+        self.cstore_scu = CStoreSCU(
+            calling_ae_title="STORESCU",
+            called_ae_title="ANYSCP",
+            called_ip="localhost",
+            called_port=11112,
+            contexts=required_contexts,
+            logger=self.scu_logger,
+        )
+
+    def tearDown(self):
+        # Remove the temporary directory and its contents
+        files_in_temp_dir = os.listdir(self.temp_dir)
+        shutil.rmtree(self.temp_dir)
+        self.test_logger.info(f"Removed the temp directory: {self.temp_dir} and its contents: {files_in_temp_dir}")
+
+        # Remove and close the memory handler for scu and test loggers
+        for logger, handler in [(self.scu_logger, self.memory_handler), (self.test_logger, self.stream_handler)]:
+            logger.removeHandler(handler)
+            handler.close()
+
+        # Terminate the storescp CLI App subprocess
+        self.process.terminate()
+        self.process.wait()
+
+        # Ensure the stdout thread has finished
+        if self.stdout_thread:
+            self.stdout_thread.join(timeout=1.0)
+
+    @parameterized.expand(
+        [
+            ("all_contexts_accepted", "SecondaryCaptureImageStorage,CTImageStorage", 3),
+            ("some_contexts_rejected", "CTImageStorage", 0),
+        ]
+    )
+    def test_verif_storage(self, name, supported_contexts, expected_success_count):
+        # sourcery skip: merge-list-append
+        """Test the Verification and Storage SOP Classes."""
+
+        # Start the Storage SCP Server
+        command = ["./tdwii_plus_examples/cli/storescp.py", "-v", "-o", self.temp_dir]
+        command.append("-s")
+        command.extend(supported_contexts.split(","))
+
+        self.storescp_started, self.process, self.stdout_thread = start_scp(command, self.test_logger)
+
+        if not self.storescp_started:
+            self.fail("storescp server failed to start.")
+            return
+
+        # Test Verification SOP Class
+        self.assertEqual(self.cstore_scu.verify().status_category, "Success")
+
+        # Test Secondary Capture Storage SOP Class
+        try:
+            success_count = self.cstore_scu.store_instances(self.sc_images)
+
+            log_messages = [record.getMessage() for record in self.memory_handler.buffer]
+            self.test_logger.info("Log messages: %s", log_messages)
+
+            self.assertEqual(success_count, expected_success_count)
+
+        except Exception as e:
+            self.test_logger.error(e)
+            raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/test_cstorescu_unit.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_unit.py
@@ -1,0 +1,137 @@
+import logging
+import unittest
+from unittest import mock
+
+from pydicom import Dataset
+from pydicom.uid import UID, generate_uid
+from pynetdicom.presentation import build_context
+
+from tdwii_plus_examples.cstorescu import CStoreSCU
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestCStoreSCU(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Setup before all tests."""
+        # Create CStoreSCU instance
+        cls.cstore_scu = CStoreSCU(
+            calling_ae_title="CALLING_AE_TITLE",
+            called_ae_title="CALLED_AE_TITLE",
+            called_ip="127.0.0.1",
+            called_port=11112,
+            logger=LOGGER,
+        )
+
+    @mock.patch("tdwii_plus_examples.cstorescu.CStoreSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.cstorescu.CStoreSCU._associate")
+    def test_store_instances(self, mock_associate, mock_handle_response):
+        """Test storing multiple DICOM instances."""
+        # Create 2 empty instances
+        ds_1 = Dataset()
+        ds_2 = Dataset()
+        instances = [ds_1, ds_2]
+
+        # Mock the association instance
+        mock_assoc_instance = mock.Mock()
+        # Mock the release method
+        mock_assoc_instance.release = mock.Mock()
+        # Mock the send_c_store method to return a success status
+        mock_assoc_instance.send_c_store.return_value = Dataset()
+        # Mock _associate to return the mock association instance
+        mock_associate.return_value = mock_assoc_instance
+        # Assign the mock association instance to the SCU's assoc attribute
+        self.cstore_scu.assoc = mock_assoc_instance
+        # Mock the _handle_response method to return a success status
+        mock_handle_response.return_value = mock.Mock(status_category="Success")
+
+        # Call the method
+        success_count = self.cstore_scu.store_instances(instances)
+
+        # Assert 2 C-STORE messages were sent and succeeded
+        self.assertEqual(success_count, 2)
+        mock_assoc_instance.send_c_store.assert_called()
+        self.assertEqual(mock_assoc_instance.send_c_store.call_count, 2)
+
+    @mock.patch("tdwii_plus_examples.cstorescu.CStoreSCU._associate")
+    def test_store_instances_association_failure(self, mock_associate):
+        """Test storing instances with association failure."""
+        # Create 1 'valid' DICOM instance
+        ds = Dataset()
+        ds.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds.SOPInstanceUID = generate_uid()
+        instances = [ds]
+
+        # Mock the association instance
+        mock_assoc_instance = mock.Mock()
+        # Mock the release method
+        mock_assoc_instance.release = mock.Mock()
+        # Mock _associate to return the mock association instance
+        mock_associate.return_value = mock_assoc_instance
+        # Set the status to "Error" to simulate an association failure
+        mock_assoc_instance.status = "Error"
+
+        # Call the method
+        success_count = self.cstore_scu.store_instances(instances)
+
+        # Assert storage failed
+        self.assertEqual(success_count, 0)
+
+    def test_set_contexts_valid(self):
+        """Test set_contexts."""
+        # Valid contexts
+        storage_contexts = [
+            build_context("1.2.840.10008.5.1.4.1.1.2"),  # CT Image Storage
+            build_context("1.2.840.10008.5.1.4.1.1.4"),  # MR Image Storage
+        ]
+        self.cstore_scu.set_contexts(storage_contexts)
+        self.assertEqual(len(self.cstore_scu.contexts), 2)
+        self.assertIn(storage_contexts[0], self.cstore_scu.contexts)
+        self.assertIn(storage_contexts[1], self.cstore_scu.contexts)
+        self.assertEqual(len(self.cstore_scu.ae.requested_contexts), 3)  # Includes Verification
+
+    def test_set_contexts_invalid(self):
+        """Test set_contexts with an invalid context."""
+        qr_abstract__syntax = "1.2.840.10008.5.1.4.1.2.2.1"  # not a storage context
+        invalid_context = build_context(qr_abstract__syntax)
+
+        with self.assertRaisesRegex(
+            ValueError, f"Only Storage Presentation Contexts are allowed. Invalid contexts: \\['{qr_abstract__syntax}'\\]"
+        ):
+            self.cstore_scu.set_contexts([invalid_context])
+
+    def test_set_contexts_from_files(self):
+        """Test set_contexts_from_files."""
+        # Create some dummy datasets
+        ds1 = Dataset()
+        ds1.SOPClassUID = "1.2.840.10008.5.1.4.1.1.2"  # CT Image Storage
+        ds2 = Dataset()
+        ds2.SOPClassUID = "1.2.840.10008.5.1.4.1.1.4"  # MR Image Storage
+        instances = [ds1, ds2]
+
+        self.cstore_scu.set_contexts_from_files(instances)
+
+        self.assertEqual(len(self.cstore_scu.contexts), 2)
+        self.assertIn(build_context(ds1.SOPClassUID, "1.2.840.10008.1.2.1"), self.cstore_scu.contexts)
+        self.assertIn(build_context(ds2.SOPClassUID, "1.2.840.10008.1.2.1"), self.cstore_scu.contexts)
+        # Check if requested contexts were updated (including verification)
+        self.assertEqual(len(self.cstore_scu.ae.requested_contexts), 3)
+
+    def test_validate_contexts_empty(self):
+        """Test _validate_contexts with an empty list."""
+        self.assertEqual(self.cstore_scu._validate_contexts([]), [])
+
+    def test_validate_contexts_valid(self):
+        """Test _validate_contexts with valid contexts."""
+        storage_contexts = [build_context(uid) for uid in ["1.2.840.10008.5.1.4.1.1.2", "1.2.840.10008.5.1.4.1.1.7"]]
+        self.assertEqual(self.cstore_scu._validate_contexts(storage_contexts), storage_contexts)
+
+    def test_validate_contexts_invalid(self):
+        """Test _validate_contexts with invalid contexts."""
+        qr_abstract__syntax = "1.2.840.10008.5.1.4.1.2.2.1"  # not a storage context
+        contexts = [build_context(qr_abstract__syntax)]
+        with self.assertRaisesRegex(
+            ValueError, f"Only Storage Presentation Contexts are allowed. Invalid contexts: \\['{qr_abstract__syntax}'\\]"
+        ):
+            self.cstore_scu._validate_contexts(contexts)

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
@@ -1,6 +1,11 @@
 import logging
+import os
+import signal
 import unittest
 from logging.handlers import MemoryHandler
+from subprocess import TimeoutExpired
+
+import psutil
 
 from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_ups
 from tdwii_plus_examples.tests.utils.utils import get_configured_logger, start_scp
@@ -32,24 +37,48 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         self.ups_instance = generate_ups()
 
     def tearDown(self):
+        # Try to gracefully terminate the process.
+        self.test_logger.info(f"Terminating process with PID: {self.process.pid}")
+        try:
+            self.process.terminate()
+            self.process.wait(timeout=1)
+            self.test_logger.info("Process terminated gracefully.")
+        except (ChildProcessError, TimeoutExpired):
+            self.test_logger.warning("Process termination timed out or process already finished.")
+
+        # Try to kill child processes.
+        try:
+            parent = psutil.Process(self.process.pid)
+            for child in parent.children(recursive=True):
+                child.kill()
+            self.test_logger.info("Child processes terminated.")
+        except psutil.NoSuchProcess:
+            self.test_logger.warning("Error killing subprocesses. Parent process not found. Probably already terminated.")
+
+        # Try to forcefully kill the process.
+        try:
+            os.kill(self.process.pid, signal.SIGKILL)
+            self.process.wait(timeout=1)  # Ensure process termination
+            self.test_logger.info("Process forcefully terminated.")
+        except OSError:
+            self.test_logger.warning("Error killing process. Probably already terminated.")
+
+        finally:
+            # Ensure the stdout thread has finished
+            if self.stdout_thread:
+                self.stdout_thread.join(timeout=1.0)
+
         # Remove and close the memory handler for scu and test loggers
         for logger, handler in [(self.scu_logger, self.memory_handler), (self.test_logger, self.stream_handler)]:
             logger.removeHandler(handler)
             handler.close()
-
-        # Terminate the upsscp CLI App subprocess
-        self.process.terminate()
-        self.process.wait()
-
-        # Ensure the stdout thread has finished
-        if self.stdout_thread:
-            self.stdout_thread.join(timeout=1.0)
 
     def test_verif_create(self):
         # Start the UPS Push SCP CLI App upsscp.py
         command = ["tdwii_plus_examples/cli/upsscp/upsscp.py", "-v"]
 
         self.upsscp_started, self.process, self.stdout_thread = start_scp(command, self.test_logger)
+        self.test_logger.info(f"Started process with PID: {self.process.pid}")
 
         if not self.upsscp_started:
             self.fail("storescp server failed to start.")

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_integration.py
@@ -1,14 +1,9 @@
 import logging
-import subprocess
-import sys
-import threading
 import unittest
 from logging.handlers import MemoryHandler
 
-from parameterized import parameterized
-from pydicom import Dataset
-from pydicom.uid import generate_uid
-
+from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_ups
+from tdwii_plus_examples.tests.utils.utils import get_configured_logger, start_scp
 from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
 
 
@@ -16,17 +11,13 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
     def setUp(self):
         # Set up the logger for the UPSPushNCreateSCU to INFO level
         # with a memory handler to store up to 100 log messages
-        self.scu_logger = logging.getLogger("upspushscu")
-        self.scu_logger.setLevel(logging.DEBUG)
-        self.memory_handler = MemoryHandler(100)
-        self.scu_logger.addHandler(self.memory_handler)
+        self.scu_logger, self.memory_handler = get_configured_logger(
+            "upspushscu", level=logging.DEBUG, handler_class=MemoryHandler, capacity=100
+        )
 
-        # Set up the logger for this test to DEBUG level
+        # Set up the logger for this test to INFO level
         # with a stream handler to print the log messages to the console
-        self.test_logger = logging.getLogger("test_upspushscu")
-        self.test_logger.setLevel(logging.DEBUG)
-        self.stream_handler = logging.StreamHandler()
-        self.test_logger.addHandler(self.stream_handler)
+        self.test_logger, self.stream_handler = get_configured_logger("test_upspushscu", level=logging.DEBUG)
 
         # Create a UPSPushNCreateSCU instance
         self.upspush_ncreate_scu = UPSPushNCreateSCU(
@@ -38,78 +29,31 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         )
 
         # Create a UPS instance for testing
-        self.ups_instance = Dataset()
-        self.ups_instance.PatientName = "Test^Patient"
-        self.ups_instance.PatientID = "123456"
-        self.ups_instance.SOPClassUID = "1.2.840.10008.5.1.4.34.6.1"
-        self.ups_instance.SOPInstanceUID = generate_uid()
-        self.ups_instance.ProcedureStepState = "SCHEDULED"
-        self.ups_instance.InputReadinessState = "READY"
-        self.ups_instance.ProcedureStepLabel = "Test UPS"
-        self.ups_instance.ScheduledProcedureStepStartDateTime = "20250101120000"
-        self.ups_instance.ScheduledProcedureStepPriority = "MEDIUM"
+        self.ups_instance = generate_ups()
 
     def tearDown(self):
-        # Remove and close the memory handler for the UPSPushNCreateSCU logger
-        self.scu_logger.removeHandler(self.memory_handler)
-        self.memory_handler.close()
+        # Remove and close the memory handler for scu and test loggers
+        for logger, handler in [(self.scu_logger, self.memory_handler), (self.test_logger, self.stream_handler)]:
+            logger.removeHandler(handler)
+            handler.close()
 
-        # Remove and close the stream handler for the test logger
-        self.test_logger.removeHandler(self.stream_handler)
-        self.stream_handler.close()
+        # Terminate the upsscp CLI App subprocess
+        self.process.terminate()
+        self.process.wait()
 
-    @parameterized.expand(
-        [
-            ("success", "Success", 0, ""),
-        ]
-    )
-    def test_run_and_check_log(
-        self,
-        name,
-        expected_status_category,
-        expected_status_code,
-        expected_status_description,
-    ):
-        # Ensure the correct Python interpreter is used for the subprocess call
-        python_executable = sys.executable
+        # Ensure the stdout thread has finished
+        if self.stdout_thread:
+            self.stdout_thread.join(timeout=1.0)
 
-        def read_stdout(process, logger, stdout_lines, server_started_flag):
-            for line in iter(process.stdout.readline, b""):
-                line = line.decode("utf-8").strip()
-                if line:
-                    stdout_lines.append(line)
-
-                    # Check if the server started successfully
-                    if "SCP server started successfully" in line:
-                        server_started_flag[0] = True
-                        break
-
+    def test_verif_create(self):
         # Start the UPS Push SCP CLI App upsscp.py
-        process = subprocess.Popen(
-            [python_executable, "tdwii_plus_examples/cli/upsscp/upsscp.py", "-v"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+        command = ["tdwii_plus_examples/cli/upsscp/upsscp.py", "-v"]
 
-        # Read stdout in a separate thread in order not to block execution of test
-        stdout_lines = []
-        server_started_flag = [False]  # Use a mutable object to share state between threads
-        stdout_thread = threading.Thread(
-            target=read_stdout, args=(process, self.test_logger, stdout_lines, server_started_flag)
-        )
-        stdout_thread.start()
+        self.upsscp_started, self.process, self.stdout_thread = start_scp(command, self.test_logger)
 
-        # Wait for the server to start or timeout
-        stdout_thread.join(timeout=1)
-
-        # If the server did not start successfully, print stdout and exit with an error
-        if not server_started_flag[0]:
-            self.test_logger.error("Error starting the server:")
-            for line in stdout_lines:
-                self.test_logger.error(line)
-            process.terminate()
-            process.wait()
-            self.fail("SCP server did not start successfully.")
+        if not self.upsscp_started:
+            self.fail("storescp server failed to start.")
+            return
 
         # Check that the SCP is running
         self.assertEqual(self.upspush_ncreate_scu.verify().status_category, "Success")
@@ -127,13 +71,6 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         except Exception as e:
             self.test_logger.error(e)
             raise
-        finally:
-            # Terminate the UPS SCP CLI App subprocess
-            process.terminate()
-            process.wait()
-
-            # Ensure the stdout thread has finished
-            stdout_thread.join()
 
 
 if __name__ == "__main__":

--- a/tdwii_plus_examples/tests/utils/generate_sop_instances.py
+++ b/tdwii_plus_examples/tests/utils/generate_sop_instances.py
@@ -1,0 +1,115 @@
+import datetime
+
+import numpy as np
+import pydicom
+from pydicom.dataset import Dataset, FileMetaDataset
+from pydicom.uid import PYDICOM_IMPLEMENTATION_UID, UID, ExplicitVRLittleEndian, generate_uid
+
+
+def generate_sc_images(num_images: int, rows: int, columns: int) -> list[Dataset]:
+    """Generates a list of DICOM datasets for Secondary Capture images.
+
+    Args:
+        num_images: The number of images to generate.
+        rows: The number of rows in each image.
+        columns: The number of columns in each image.
+
+    Returns:
+        A list of DICOM datasets, each representing a Secondary Capture image.
+    """
+    # Generate a single StudyInstanceUID for all images
+    study_instance_uid = generate_uid()
+    series_instance_uid = generate_uid()
+
+    datasets = []
+
+    for i in range(num_images):
+        ds = Dataset()
+
+        # Set Patient Module required attributes
+        ds.PatientName = "Test^Object"
+        ds.PatientID = "123456"
+        ds.PatientBirthDate = "19930822"
+        ds.PatientSex = "O"
+
+        # Set General Study Module required attributes
+        dt = datetime.datetime.now()
+        ds.StudyDate = dt.strftime("%Y%m%d")
+        ds.StudyTime = dt.strftime("%H%M%S.%f")  # long format with micro seconds
+        ds.AccessionNumber = ""
+        ds.ReferringPhysicianName = ""
+        ds.StudyInstanceUID = study_instance_uid
+        ds.StudyID = "1"
+
+        # Set General Series Module required attributes
+        ds.Modality = "SC"
+        ds.SeriesInstanceUID = series_instance_uid
+        ds.SeriesNumber = "1"
+
+        # Set General Equipment Module required attributes
+        ds.Manufacturer = "ME"
+
+        # Set SC Equipment Module required attributes
+        ds.ConversionType = "WSD"
+
+        # Set General Image Module required attributes
+        ds.ImageType = ["ORIGINAL", "PRIMARY", "BLANK"]  # not required but usually set
+        dt = datetime.datetime.now()
+        ds.ContentDate = dt.strftime("%Y%m%d")
+        ds.ContentTime = dt.strftime("%H%M%S.%f")  # long format with micro seconds
+        ds.InstanceNumber = f"{i + 1}"
+
+        # Set Image Pixel Module required attributes        ds.SamplesPerPixel = 1
+        ds.SamplesPerPixel = 1
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.Rows = rows
+        ds.Columns = columns
+        ds.BitsAllocated = 16
+        ds.BitsStored = 16
+        ds.HighBit = 15
+        ds.PixelRepresentation = 0
+        ds.PixelData = np.zeros((rows, columns), dtype=np.uint16).tobytes()
+
+        # Add SOP Common Module required attributes
+        ds.SOPInstanceUID = pydicom.uid.generate_uid()
+        ds.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.7")  # SC Image Storage
+
+        # Other attributes which may be required by remote application
+        ds.PatientOrientation = ""
+
+        # Populate required values for file meta information
+        file_meta = FileMetaDataset()
+        file_meta.MediaStorageSOPClassUID = UID("1.2.840.10008.5.1.4.1.1.7")  # SC Image Storage
+        file_meta.MediaStorageSOPInstanceUID = ds.SOPInstanceUID
+        file_meta.ImplementationClassUID = PYDICOM_IMPLEMENTATION_UID
+        file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+        file_meta.is_little_endian = True
+        file_meta.is_implicit_VR = False
+
+        # Add the file meta information
+        ds.file_meta = file_meta
+
+        datasets.append(ds)
+
+    return datasets
+
+
+def generate_ups() -> Dataset:
+    """Generates a DICOM datasets for UPS.
+
+    Returns:
+        A DICOM datasets representing a UPS.
+    """
+    ds = Dataset()
+
+    ds.PatientName = "Test^Patient"
+    ds.PatientID = "123456"
+    ds.SOPClassUID = "1.2.840.10008.5.1.4.34.6.1"
+    ds.SOPInstanceUID = generate_uid()
+    ds.ProcedureStepState = "SCHEDULED"
+    ds.InputReadinessState = "READY"
+    ds.ProcedureStepLabel = "Test UPS"
+    ds.ScheduledProcedureStepStartDateTime = "20250101120000"
+    ds.ScheduledProcedureStepPriority = "MEDIUM"
+
+    return ds

--- a/tdwii_plus_examples/tests/utils/utils.py
+++ b/tdwii_plus_examples/tests/utils/utils.py
@@ -1,0 +1,74 @@
+import logging
+import subprocess
+import sys
+import threading
+
+
+def get_configured_logger(logger_name, level=logging.INFO, handler_class=logging.StreamHandler, capacity=None):
+    """Returns a configured logger with a handler.
+
+    Args:
+        logger_name (str): The name of the logger.
+        level (int): The logging level. Defaults to logging.INFO.
+        handler_class (logging.Handler): The handler class to use. Defaults to logging.StreamHandler.
+        capacity (int, optional): The capacity of the handler if it supports it (e.g., MemoryHandler).
+
+    Returns:
+        tuple[logging.Logger, logging.Handler]: A tuple containing the logger and the handler.
+    """
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    handler = handler_class(capacity) if capacity else handler_class()
+    logger.addHandler(handler)
+    return logger, handler
+
+
+def start_scp(command: list[str], logger, timeout: float = 1.0, success_message="SCP server started successfully") -> bool:
+    """Starts an external SCP process and waits for a success message.
+
+    Args:
+        command (list[str]): The command to execute.
+        logger: The logger to use for messages.
+        timeout (float): Timeout in seconds.
+        success_message (str): The message to watch on stdout that signals successful startup.
+
+    Returns:
+        True if the process started successfully, False otherwise.
+    """
+    python_executable = sys.executable
+    try:
+        process = subprocess.Popen(
+            [python_executable] + command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except Exception as e:
+        logger.error(f"Error starting process: {e}")
+        return False, None, None  # Return False and None for process and thread
+
+    stdout_lines = []
+    process_started_flag = [False]
+    stdout_thread = threading.Thread(target=_read_stdout, args=(process, stdout_lines, process_started_flag, success_message))
+    stdout_thread.start()
+    stdout_thread.join(timeout=timeout)
+
+    if not process_started_flag[0]:
+        logger.error("Process did not start successfully.")
+        for line in stdout_lines:
+            logger.error(line)
+        process.terminate()
+        process.wait()
+        return False, process, stdout_thread
+
+    return True, process, stdout_thread
+
+
+def _read_stdout(process, stdout_lines, process_started_flag, success_message):
+    """Reads stdout from the process."""
+    for line in iter(process.stdout.readline, b""):
+        line = line.decode("utf-8").strip()
+        if line:
+            stdout_lines.append(line)
+            if success_message in line:
+                process_started_flag[0] = True
+                break


### PR DESCRIPTION
This merge request addresses part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It refactors storescu.py from the tdwii_plus_examples/rtdbdi_creator folder.
The StoreSCU class is refactored as CStoreSCU and moved to tdwii_plus_examples package folder in cstorescu.py.
CStoreSCU is derived from a BaseSCU class.
The storescu CLI application in tdwii_plus_examples package folder is also refactored as an storescu.py CLI application in the tdwii_plus_examples/cli folder.
Tests are provided.
Finally, the GUI applications in tdwii_plus_examples/rtbdi_creator and tdwii_plus_examples/tdd folders are refactored to use CStoreSCU class.

Note that I was not able to perform a manual integration test of the storage of a treatment record from the tdd_widget.py.

## Summary by Sourcery

Refactor the DICOM C-STORE functionality into a reusable `CStoreSCU` class and update dependent components.

New Features:
- Refactor and relocate the `storescu` command-line application to `tdwii_plus_examples/cli/storescu.py`, utilizing the `CStoreSCU` class.
- Introduce a `CStoreSCU` class for handling DICOM C-STORE operations, inheriting from `BaseSCU`.
- Add a command-line interface for `CStoreSCU` functionality.
- Add unit tests for the `CStoreSCU` class.
- Add integration tests for the `CStoreSCU` class and the `storescu` CLI.
- Add test utilities for generating SOP instances and managing SCP processes.

Enhancements:
- Extract C-STORE logic into a new `CStoreSCU` class located in `tdwii_plus_examples/cstorescu.py`.
- Derive `CStoreSCU` from the `BaseSCU` class.
- Update GUI applications (`mainbdiwidget.py`, `tdd_widget.py`) to utilize the new `CStoreSCU` class for C-STORE operations.
- Improve AE configuration loading in the `mainbdiwidget` GUI.
- Refactor existing integration tests for `UPSPushNCreateSCU` to use common utilities.
- Introduce common test utilities for generating SOP instances and managing SCP processes during tests (`tests/utils`).