### PR TITLE
Handle Association Results in BaseSCU Class

### DIFF
--- a/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
+++ b/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
@@ -81,14 +81,14 @@ class PPVS_SubscriberWidget(QWidget):
                     self.ui.machine_name_line_edit.setText(machine_name)
                 logging.warning(f"Completed Parsing of {config_file_path}")
             except Exception:
-                logging.warning("Difficulty parsing config file " f"{config_file_path}")
+                logging.warning(f"Difficulty parsing config file {config_file_path}")
         except OSError as config_file_error:
-            logging.exception("Problem parsing config file " f"{config_file_path}: {config_file_error}")
+            logging.exception(f"Problem parsing config file {config_file_path}: {config_file_error}")
 
         if "ae_title" in default_dict and "import_staging_directory" in default_dict:
             self._restart_scp()
         else:
-            logging.error(f"AE Title and Staging Directory missing from " f"config file {config_file_path}")
+            logging.error(f"AE Title and Staging Directory missing from config file {config_file_path}")
 
     @Slot()
     def _import_staging_dir_clicked(self):
@@ -343,9 +343,10 @@ class PPVS_SubscriberWidget(QWidget):
         if result.status_category != "Success":
             status = False
             logging.error("Error subscribing to UPS: " + result.status_description)
-        if result.status_category == "Success" and self.watch_scu is None:
+        if result.status_category == "Success":
             status = True
-            self.watch_scu = watch_scu
+            if self.watch_scu is None:
+                self.watch_scu = watch_scu
 
         return status
 

--- a/tdwii_plus_examples/basescu.py
+++ b/tdwii_plus_examples/basescu.py
@@ -12,16 +12,21 @@ from pynetdicom.status import GENERAL_STATUS, code_to_category
 
 class BaseSCU:
     """
-    The BaseSCU class is a base class for DICOM Service Class Providers (SCUs).
+    The BaseSCU class is a base class for DICOM Service Class Users (SCUs).
 
     This class provides basic functionality for creating and managing
     a DICOM Service Class Provider (SCU) including setting up the
     Application Entity (AE), establishing and Association with an SCP and
     handling incoming responses from SCP.
+    It also implements the Verification SOP Class SCU.
 
     Usage:
-        To use the BaseSCU class, create a subclass and override
-        the [_add_contexts] method to add requested presentation contexts.
+        To use the BaseSCU class, create a subclass then,
+        override:
+        - [_add_contexts] method to add requested presentation contexts.
+        - [_get_status_description] method to add response status codes.
+        use:
+        - [_associate] method to implement Service primitives requests
 
     Attributes:
         ae_title (str): The title of the Application Entity (AE)
@@ -30,16 +35,18 @@ class BaseSCU:
         logger(logging.Logger): A logger instance
 
     Methods:
-        _add_requested_contexts(self)
-            Adds presentation contexts to the SCU instance.
-        _associate(self)
-            Open an Association of the SCU instance to an SCP.
-        _handle_response(self)
-            Handle the response of the request sent by the SCU.
-        all_contexts_accepted(self, assoc)
-            Check if all requested presentation contexts were accepted.
+        _add_requested_context()
+            Adds the Verification SOP Class presentation context.
+            Should be overridden by subclasses.
+        _associate()
+            Establishes association with remote AE.
+        _get_status_description()
+            Retrieves the description for a given status code.
+            Should be overridden by subclasses.
+        set_called_ae()
+            Sets the called AE parameters.
         verify()
-            Send a Verification (C-ECHO) request from the SCU
+            Sends a verification request.
     """
 
     def __init__(
@@ -51,10 +58,11 @@ class BaseSCU:
         called_ae_title: str = None,
     ):
         """
-        Initializes a new instance of the Base SCU AE class.
-        This method sets up the AE with the provided parameters
-        and adds the requested presentation context to negotiate
-        the UPS Push SOP Class.
+        Initializes a BaseSCU instance.
+
+        This method sets up the AE and calls the method _add_requested_context
+        which is meant to be overriden by subclasses.
+        BaseSCU adds the Verification SOP Class presentation context.
 
         Parameters
         ----------
@@ -64,8 +72,8 @@ class BaseSCU:
             The IP address of the called AE.
         called_port : int
             The port number of the called AE.
-        called_ae_title : str
-            The AE title of the called AE.
+        called_ae_title : str, optional
+            The AE title of the called AE. If None, "ANY-SCP" is used.
         calling_ae_title : str
             The AE title of the calling AE.
         """
@@ -103,11 +111,11 @@ class BaseSCU:
 
     def _add_requested_context(self):
         """
-        Adds the DICOM UPS Push SOP Class presentation context to the AE.
+        Adds the DICOM Verification SOP Class presentation context to the AE.
         Default transfer syntaxes are included.
 
-        This method may be overridden in derived classes if another SOP
-        Class needs to be negotiated.
+        Derived classes *must* override this method to add the presentation
+        contexts for the specific SOP Classes they support.
         """
         self.ae.add_requested_context(Verification)
         self.logger.debug(f"Verification Presentation context added: \n {self.ae.requested_contexts[0]}")
@@ -115,60 +123,120 @@ class BaseSCU:
     # Create a named tuple to hold the result of the Association
     AssociationResult = namedtuple("AssociationResult", ["status", "description", "accepted_sop_classes"])
 
-    def _associate(self):
+    def _associate(self, required_sop_classes=None, verbose: bool = True):
         """
-        Establish an association with the remote AE and check contexts.
+        Establishes an association with the remote AE.
+
+        Returns an AssociationResult named tuple containing the status, accepted SOP classes, and a description.
+        The status is "Success" if all requested presentation contexts are accepted, "Warning" if only some are
+        accepted and "Error" if the association fails.
 
         Returns:
-            AssociationResult: A named tuple containing the status, accepted SOP classes, and description.
+            An AssociationResult namedtuple with the following fields:
+
+            - status (str): The status of the association ("Success", "Warning", or "Error").
+            - description (str): A description of the association result.
+            - accepted_sop_classes (list of UID): A list of accepted SOP Class UIDs.
         """
         if (self.called_ip is None or self.called_ip == "") or self.called_port is None:
-            return self.AssociationResult(status="Error", description="Called AE parameters not set", accepted_sop_classes=[])
-        else:
-            if self.called_ae_title is None:
-                self.called_ae_title = "ANYSCP"
-                self.logger.warning(f"Using default Called Application Entity Title: {self.called_ae_title}")
+            if verbose:
+                return self.AssociationResult(
+                    status="Error", description="Called AE parameters not set", accepted_sop_classes=[]
+                )
+            else:
+                False
 
-            self.assoc = self.ae.associate(self.called_ip, self.called_port, ae_title=self.called_ae_title)
-            if not self.assoc.is_established:
+        if self.called_ae_title is None:
+            self.called_ae_title = "ANYSCP"
+            self.logger.warning(f"Using default Called Application Entity Title: {self.called_ae_title}")
+
+        self.assoc = self.ae.associate(self.called_ip, self.called_port, ae_title=self.called_ae_title)
+        if not self.assoc.is_established:
+            if verbose:
                 return self.AssociationResult(
                     status="Error", description="Association could not be established", accepted_sop_classes=[]
                 )
-            self.logger.debug("Association established")
+            else:
+                return False
 
-            # Initialize status of future requests
-            self.status = False
+        self.logger.debug("Association established")
 
-            # Check if all requested contexts were accepted
-            return self._all_contexts_accepted(self.assoc)
+        # Initialize status of future requests
+        self.status = False
 
-    def _all_contexts_accepted(self, assoc: Association) -> AssociationResult:
+        # Check if all requested contexts were accepted
+        assoc_result = self._check_accepted_sop_classes(self.assoc)
+        if assoc_result.status:
+            if verbose:
+                return self.AssociationResult(
+                    status="Success",
+                    description="All requested SOP Classes were accepted",
+                    accepted_sop_classes=[UID(uid) for uid in assoc_result.accepted_sop_classes],
+                )
+            else:
+                return True
+        else:
+            # Check if all required contexts were accepted
+            assoc_result = self._validate_sop_classes(assoc_result, required_sop_classes)
+        return assoc_result if verbose else assoc_result.status == "Success"
+
+    def _check_accepted_sop_classes(self, assoc: Association) -> AssociationResult:
         """
-        Check if all requested presentation contexts were accepted.
+        Check if all requested DICOM SOP classes are accepted.
+
+        Returns an AssociationResult indicating "Success" if all SOP classes are accepted
+        and "Warning" if only some are accepted.
 
         Args:
-            assoc (Association): The established association object.
+            assoc (pynetdicom.association.Association): The established association.
 
         Returns:
-            AssociationResult: A named tuple containing the status, accepted SOP classes, and description.
+            An AssociationResult namedtuple.
         """
         requested_abstract_syntaxes = {ctx.abstract_syntax for ctx in self.ae.requested_contexts}
         accepted_abstract_syntaxes = {ctx.abstract_syntax for ctx in assoc.accepted_contexts}
 
-        refused_abstract_syntaxes = requested_abstract_syntaxes - accepted_abstract_syntaxes
+        rejected_abstract_syntaxes = requested_abstract_syntaxes - accepted_abstract_syntaxes
 
-        if refused_abstract_syntaxes:
+        if rejected_abstract_syntaxes:
             accepted_sop_classes = [UID(uid) for uid in accepted_abstract_syntaxes]
-            description = "The following SOP classes were not accepted: " + ", ".join(
-                str(uid) for uid in refused_abstract_syntaxes
+            self.logger.warning(
+                "The following SOP Classes were rejected: " + ", ".join(str(uid) for uid in rejected_abstract_syntaxes)
             )
-            return self.AssociationResult(status="Warning", description=description, accepted_sop_classes=accepted_sop_classes)
+            return self.AssociationResult(status=False, description="", accepted_sop_classes=accepted_sop_classes)
 
         return self.AssociationResult(
-            status="Success",
-            description="All requested presentation contexts were accepted",
+            status=True,
+            description="",
             accepted_sop_classes=[UID(uid) for uid in accepted_abstract_syntaxes],
         )
+
+    def _validate_sop_classes(self, assoc_result, required_sop_classes=None):
+        """Validates if all required SOP classes are accepted.
+
+        Args:
+            assoc_result (AssociationResult): The association result.
+            required_sop_classes (list, optional): A list of required SOP Class UIDs.
+
+        Returns:
+            An AssociationResult namedtuple.
+        """
+        accepted_sop_classes = {UID(uid) for uid in assoc_result.accepted_sop_classes}
+
+        # Use a set for efficient check
+        if required_sop_classes:
+            required_sop_classes = {UID(uid) for uid in required_sop_classes}
+        else:
+            required_sop_classes = {context.abstract_syntax for context in self.ae.requested_contexts}
+
+        if not required_sop_classes.issubset(accepted_sop_classes):
+            missing_sop_classes = list(required_sop_classes - accepted_sop_classes)
+            description = f"The following required SOP classes were rejected: {', '.join(map(str, missing_sop_classes))}"
+            self.logger.error(description)
+            self.assoc.release()
+            return self.AssociationResult("Error", description, list(accepted_sop_classes))
+
+        return self.AssociationResult("Success", "All required SOP classes were accepted", list(accepted_sop_classes))
 
     # Create a named tuple to hold the response status and dataset
     PrimitiveResult = namedtuple("PrimitiveResult", ["status_category", "status_code", "status_description", "dataset"])
@@ -220,9 +288,37 @@ class BaseSCU:
         return self.PrimitiveResult(category, status_code, description, rsp_ds)
 
     def _get_status_description(self, status_code):
+        """
+        Retrieves the description for a given status code.
+
+        This method retrieves the description associated with a given status
+        code from the GENERAL_STATUS dictionary. If the status code is not
+        found, it returns "Unknown".  This method is intended to be overridden
+        by subclasses to provide more specific status descriptions.
+
+        Args:
+            status_code (int): The status code to look up.
+
+        Returns:
+            str: The description of the status code.
+        """
         return GENERAL_STATUS.get(status_code, ("Unknown", "Unknown status code"))[1]
 
     def set_called_ae(self, called_ip: str, called_port: int, called_ae_title: str = None):
+        """
+        Sets the called AE parameters.
+
+        This method allows setting the called AE parameters (IP, port, and
+        AE title) after the BaseSCU object has been initialized.  It's
+        useful when the called AE information is not available during
+        object creation.
+
+        Args:
+            called_ip (str): The IP address of the called AE.
+            called_port (int): The port number of the called AE.
+            called_ae_title (str, optional): The AE title of the called AE.
+                Defaults to "ANY-SCP".
+        """
         self.called_ip = called_ip
         self.called_port = called_port
         if called_ae_title is None or called_ae_title == "":
@@ -245,7 +341,7 @@ class BaseSCU:
         PrimitiveResult:
             A named tuple containing the status category, status code, status description, and dataset.
         """
-        assoc_result = self._associate()
+        assoc_result = self._associate(required_sop_classes=[Verification])
 
         if assoc_result.status == "Error":
             return self.PrimitiveResult("AssocFailure", 0xD000, assoc_result.description, None)

--- a/tdwii_plus_examples/cli/storescu.py
+++ b/tdwii_plus_examples/cli/storescu.py
@@ -84,7 +84,7 @@ def main():
     parser.add_argument("ip", type=str, help="IP address or hotname of called AE")
     parser.add_argument("port", type=int, help="TCP port number of called AE")
     parser.add_argument(
-        "path", metavar="path", nargs="+", help="DICOM file or directory containing SOP instances to store", type=str
+        "path", metavar="path", nargs="*", help="DICOM file or directory containing SOP instances to store", type=str
     )
     parser.add_argument("-r", "--recurse", help="recursively search the given directory", action="store_true")
     parser.add_argument("-aet", "--ae_title", type=str, default="STORESCU", help="Application Entity Title")
@@ -95,6 +95,12 @@ def main():
     parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
 
     args = parser.parse_args()
+
+    if not args.echo and not args.path:
+        parser.error("Either -e/--echo or a path must be provided")
+
+    if args.echo and args.path:
+        print("Warning: Path argument is ignored when using -e/--echo option")
 
     if args.quiet:
         log_level = logging.CRITICAL
@@ -129,7 +135,7 @@ def main():
             print(f"Verification (C-ECHO) failed: {num_created_instances.status_description}")
 
     # UPS instances creation requested
-    elif args.path is not None:
+    elif args.path:
         valid_paths, invalid_paths = get_files(args.path, args.recurse)
 
         for path in invalid_paths:

--- a/tdwii_plus_examples/tests/test_cstorescu_integration.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_integration.py
@@ -99,7 +99,8 @@ class TestCStoreSCU(unittest.TestCase):
     @parameterized.expand(
         [
             ("all_contexts_accepted", "SecondaryCaptureImageStorage,CTImageStorage", 3),
-            ("some_contexts_rejected", "CTImageStorage", 0),
+            ("required_contexts_rejected", "CTImageStorage", 0),
+            ("non_required_contexts_rejected", "SecondaryCaptureImageStorage", 3),
         ]
     )
     def test_verif_storage(self, name, supported_contexts, expected_success_count):

--- a/tdwii_plus_examples/upspushncreatescu.py
+++ b/tdwii_plus_examples/upspushncreatescu.py
@@ -64,10 +64,10 @@ class UPSPushNCreateSCU(BaseSCU):
                 f"Some instances were ignored because their SOPClassUID did not match UnifiedProcedureStepPush. "
                 f"Total instances provided: {len(instances)}, valid instances: {len(valid_instances)}"
             )
-        assoc_result = self._associate()
+        assoc_result = self._associate(required_sop_classes=[UnifiedProcedureStepPush], verbose=False)
         success_count = 0
 
-        if not self._handle_association_status(assoc_result):
+        if not assoc_result:
             return 0
 
         for msg_id, instance in enumerate(valid_instances, start=0):
@@ -90,19 +90,6 @@ class UPSPushNCreateSCU(BaseSCU):
         self.logger.debug("Association released")
 
         return success_count
-
-    def _handle_association_status(self, assoc_result) -> bool:
-        if assoc_result.status == "Error":
-            self.logger.error(f"Association failed: {assoc_result.description}")
-            return False
-        if assoc_result.status == "Warning":
-            accepted_sop_names = [f"[{UID(uid).name}]" for uid in assoc_result.accepted_sop_classes]
-            self.logger.warning(f"{assoc_result.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
-            if "[Unified Procedure Step - Push SOP Class]" not in accepted_sop_names:
-                self.assoc.release()
-                self.logger.error(f"Association failed: {assoc_result.description}")
-                return False
-        return True
 
     def _send_upspushncreate_request(
         self,


### PR DESCRIPTION
Still part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It refactors BaseSCU Class in basescu.py to:
- validate that the association results includes the required SOP classes so subclasses no longer have to implement such redundant logic and just have to specify which SOP classes from the requested presentation contexts are required (all by default).
- allow either simple (boolean) of detailed (namedtuple) return value of the _association() method with the `verbose` flag.

Details
- Renamed all_accepted_contexts for consistency
- Add Required SOP Class Validation in _associate method
- Add verbose option in _associate method
- Fix and Improve BaseSCU docstrings
- Modify derived SCU Classes accordingly
- Modifed Tests accordingly
- Fix bug in PPVS UPS subscription
- Fix bug in storescu CLI App where -e option did not require path arg

## Summary by Sourcery

Refactor BaseSCU class to improve association handling and SOP class validation, enhancing flexibility and reducing redundant logic in derived classes.

New Features:
- Add verbose option to _associate method for flexible return values
- Implement required SOP class validation during association

Bug Fixes:
- Fix bug in PPVS UPS subscription
- Fix storescu CLI app to require path or echo option

Enhancements:
- Improve BaseSCU class docstrings
- Rename methods for consistency
- Simplify association status checking
- Add more robust SOP class acceptance validation

Tests:
- Update unit and integration tests to match new association handling
- Add test cases for SOP class validation