### PR TITLE
Refactor nactionscu

### DIFF
--- a/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
+++ b/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
@@ -81,14 +81,14 @@ class PPVS_SubscriberWidget(QWidget):
                     self.ui.machine_name_line_edit.setText(machine_name)
                 logging.warning(f"Completed Parsing of {config_file_path}")
             except Exception:
-                logging.warning("Difficulty parsing config file " f"{config_file_path}")
+                logging.warning(f"Difficulty parsing config file {config_file_path}")
         except OSError as config_file_error:
-            logging.exception("Problem parsing config file " f"{config_file_path}: {config_file_error}")
+            logging.exception(f"Problem parsing config file {config_file_path}: {config_file_error}")
 
         if "ae_title" in default_dict and "import_staging_directory" in default_dict:
             self._restart_scp()
         else:
-            logging.error(f"AE Title and Staging Directory missing from " f"config file {config_file_path}")
+            logging.error(f"AE Title and Staging Directory missing from config file {config_file_path}")
 
     @Slot()
     def _import_staging_dir_clicked(self):
@@ -343,9 +343,10 @@ class PPVS_SubscriberWidget(QWidget):
         if result.status_category != "Success":
             status = False
             logging.error("Error subscribing to UPS: " + result.status_description)
-        if result.status_category == "Success" and self.watch_scu is None:
+        if result.status_category == "Success":
             status = True
-            self.watch_scu = watch_scu
+            if self.watch_scu is None:
+                self.watch_scu = watch_scu
 
         return status
 

--- a/tdwii_plus_examples/_ups_action_type_id.py
+++ b/tdwii_plus_examples/_ups_action_type_id.py
@@ -1,0 +1,11 @@
+# tdwii_plus_examples/action_type_id.py
+from enum import Enum, unique
+
+
+@unique
+class UPSActionTypeID(Enum):
+    CHANGE_UPS_STATE = 1
+    REQUEST_UPS_CANCEL = 2
+    SUBSCRIBE = 3
+    UNSUBSCRIBE = 4
+    SUSPEND = 5

--- a/tdwii_plus_examples/basescu.py
+++ b/tdwii_plus_examples/basescu.py
@@ -12,16 +12,21 @@ from pynetdicom.status import GENERAL_STATUS, code_to_category
 
 class BaseSCU:
     """
-    The BaseSCU class is a base class for DICOM Service Class Providers (SCUs).
+    The BaseSCU class is a base class for DICOM Service Class Users (SCUs).
 
     This class provides basic functionality for creating and managing
     a DICOM Service Class Provider (SCU) including setting up the
     Application Entity (AE), establishing and Association with an SCP and
     handling incoming responses from SCP.
+    It also implements the Verification SOP Class SCU.
 
     Usage:
-        To use the BaseSCU class, create a subclass and override
-        the [_add_contexts] method to add requested presentation contexts.
+        To use the BaseSCU class, create a subclass then,
+        override:
+        - [_add_contexts] method to add requested presentation contexts.
+        - [_get_status_description] method to add response status codes.
+        use:
+        - [_associate] method to implement Service primitives requests
 
     Attributes:
         ae_title (str): The title of the Application Entity (AE)
@@ -30,16 +35,18 @@ class BaseSCU:
         logger(logging.Logger): A logger instance
 
     Methods:
-        _add_requested_contexts(self)
-            Adds presentation contexts to the SCU instance.
-        _associate(self)
-            Open an Association of the SCU instance to an SCP.
-        _handle_response(self)
-            Handle the response of the request sent by the SCU.
-        all_contexts_accepted(self, assoc)
-            Check if all requested presentation contexts were accepted.
+        _add_requested_context()
+            Adds the Verification SOP Class presentation context.
+            Should be overridden by subclasses.
+        _associate()
+            Establishes association with remote AE.
+        _get_status_description()
+            Retrieves the description for a given status code.
+            Should be overridden by subclasses.
+        set_called_ae()
+            Sets the called AE parameters.
         verify()
-            Send a Verification (C-ECHO) request from the SCU
+            Sends a verification request.
     """
 
     def __init__(
@@ -51,10 +58,11 @@ class BaseSCU:
         called_ae_title: str = None,
     ):
         """
-        Initializes a new instance of the Base SCU AE class.
-        This method sets up the AE with the provided parameters
-        and adds the requested presentation context to negotiate
-        the UPS Push SOP Class.
+        Initializes a BaseSCU instance.
+
+        This method sets up the AE and calls the method _add_requested_context
+        which is meant to be overriden by subclasses.
+        BaseSCU adds the Verification SOP Class presentation context.
 
         Parameters
         ----------
@@ -64,8 +72,8 @@ class BaseSCU:
             The IP address of the called AE.
         called_port : int
             The port number of the called AE.
-        called_ae_title : str
-            The AE title of the called AE.
+        called_ae_title : str, optional
+            The AE title of the called AE. If None, "ANY-SCP" is used.
         calling_ae_title : str
             The AE title of the calling AE.
         """
@@ -103,11 +111,11 @@ class BaseSCU:
 
     def _add_requested_context(self):
         """
-        Adds the DICOM UPS Push SOP Class presentation context to the AE.
+        Adds the DICOM Verification SOP Class presentation context to the AE.
         Default transfer syntaxes are included.
 
-        This method may be overridden in derived classes if another SOP
-        Class needs to be negotiated.
+        Derived classes *must* override this method to add the presentation
+        contexts for the specific SOP Classes they support.
         """
         self.ae.add_requested_context(Verification)
         self.logger.debug(f"Verification Presentation context added: \n {self.ae.requested_contexts[0]}")
@@ -115,60 +123,120 @@ class BaseSCU:
     # Create a named tuple to hold the result of the Association
     AssociationResult = namedtuple("AssociationResult", ["status", "description", "accepted_sop_classes"])
 
-    def _associate(self):
+    def _associate(self, required_sop_classes=None, verbose: bool = True):
         """
-        Establish an association with the remote AE and check contexts.
+        Establishes an association with the remote AE.
+
+        Returns an AssociationResult named tuple containing the status, accepted SOP classes, and a description.
+        The status is "Success" if all requested presentation contexts are accepted, "Warning" if only some are
+        accepted and "Error" if the association fails.
 
         Returns:
-            AssociationResult: A named tuple containing the status, accepted SOP classes, and description.
+            An AssociationResult namedtuple with the following fields:
+
+            - status (str): The status of the association ("Success", "Warning", or "Error").
+            - description (str): A description of the association result.
+            - accepted_sop_classes (list of UID): A list of accepted SOP Class UIDs.
         """
         if (self.called_ip is None or self.called_ip == "") or self.called_port is None:
-            return self.AssociationResult(status="Error", description="Called AE parameters not set", accepted_sop_classes=[])
-        else:
-            if self.called_ae_title is None:
-                self.called_ae_title = "ANYSCP"
-                self.logger.warning(f"Using default Called Application Entity Title: {self.called_ae_title}")
+            if verbose:
+                return self.AssociationResult(
+                    status="Error", description="Called AE parameters not set", accepted_sop_classes=[]
+                )
+            else:
+                False
 
-            self.assoc = self.ae.associate(self.called_ip, self.called_port, ae_title=self.called_ae_title)
-            if not self.assoc.is_established:
+        if self.called_ae_title is None:
+            self.called_ae_title = "ANYSCP"
+            self.logger.warning(f"Using default Called Application Entity Title: {self.called_ae_title}")
+
+        self.assoc = self.ae.associate(self.called_ip, self.called_port, ae_title=self.called_ae_title)
+        if not self.assoc.is_established:
+            if verbose:
                 return self.AssociationResult(
                     status="Error", description="Association could not be established", accepted_sop_classes=[]
                 )
-            self.logger.debug("Association established")
+            else:
+                return False
 
-            # Initialize status of future requests
-            self.status = False
+        self.logger.debug("Association established")
 
-            # Check if all requested contexts were accepted
-            return self._all_contexts_accepted(self.assoc)
+        # Initialize status of future requests
+        self.status = False
 
-    def _all_contexts_accepted(self, assoc: Association) -> AssociationResult:
+        # Check if all requested contexts were accepted
+        assoc_result = self._check_accepted_sop_classes(self.assoc)
+        if assoc_result.status:
+            if verbose:
+                return self.AssociationResult(
+                    status="Success",
+                    description="All requested SOP Classes were accepted",
+                    accepted_sop_classes=[UID(uid) for uid in assoc_result.accepted_sop_classes],
+                )
+            else:
+                return True
+        else:
+            # Check if all required contexts were accepted
+            assoc_result = self._validate_sop_classes(assoc_result, required_sop_classes)
+        return assoc_result if verbose else assoc_result.status == "Success"
+
+    def _check_accepted_sop_classes(self, assoc: Association) -> AssociationResult:
         """
-        Check if all requested presentation contexts were accepted.
+        Check if all requested DICOM SOP classes are accepted.
+
+        Returns an AssociationResult indicating "Success" if all SOP classes are accepted
+        and "Warning" if only some are accepted.
 
         Args:
-            assoc (Association): The established association object.
+            assoc (pynetdicom.association.Association): The established association.
 
         Returns:
-            AssociationResult: A named tuple containing the status, accepted SOP classes, and description.
+            An AssociationResult namedtuple.
         """
         requested_abstract_syntaxes = {ctx.abstract_syntax for ctx in self.ae.requested_contexts}
         accepted_abstract_syntaxes = {ctx.abstract_syntax for ctx in assoc.accepted_contexts}
 
-        refused_abstract_syntaxes = requested_abstract_syntaxes - accepted_abstract_syntaxes
+        rejected_abstract_syntaxes = requested_abstract_syntaxes - accepted_abstract_syntaxes
 
-        if refused_abstract_syntaxes:
+        if rejected_abstract_syntaxes:
             accepted_sop_classes = [UID(uid) for uid in accepted_abstract_syntaxes]
-            description = "The following SOP classes were not accepted: " + ", ".join(
-                str(uid) for uid in refused_abstract_syntaxes
+            self.logger.warning(
+                "The following SOP Classes were rejected: " + ", ".join(str(uid) for uid in rejected_abstract_syntaxes)
             )
-            return self.AssociationResult(status="Warning", description=description, accepted_sop_classes=accepted_sop_classes)
+            return self.AssociationResult(status=False, description="", accepted_sop_classes=accepted_sop_classes)
 
         return self.AssociationResult(
-            status="Success",
-            description="All requested presentation contexts were accepted",
+            status=True,
+            description="",
             accepted_sop_classes=[UID(uid) for uid in accepted_abstract_syntaxes],
         )
+
+    def _validate_sop_classes(self, assoc_result, required_sop_classes=None):
+        """Validates if all required SOP classes are accepted.
+
+        Args:
+            assoc_result (AssociationResult): The association result.
+            required_sop_classes (list, optional): A list of required SOP Class UIDs.
+
+        Returns:
+            An AssociationResult namedtuple.
+        """
+        accepted_sop_classes = {UID(uid) for uid in assoc_result.accepted_sop_classes}
+
+        # Use a set for efficient check
+        if required_sop_classes:
+            required_sop_classes = {UID(uid) for uid in required_sop_classes}
+        else:
+            required_sop_classes = {context.abstract_syntax for context in self.ae.requested_contexts}
+
+        if not required_sop_classes.issubset(accepted_sop_classes):
+            missing_sop_classes = list(required_sop_classes - accepted_sop_classes)
+            description = f"The following required SOP classes were rejected: {', '.join(map(str, missing_sop_classes))}"
+            self.logger.error(description)
+            self.assoc.release()
+            return self.AssociationResult("Error", description, list(accepted_sop_classes))
+
+        return self.AssociationResult("Success", "All required SOP classes were accepted", list(accepted_sop_classes))
 
     # Create a named tuple to hold the response status and dataset
     PrimitiveResult = namedtuple("PrimitiveResult", ["status_category", "status_code", "status_description", "dataset"])
@@ -220,9 +288,37 @@ class BaseSCU:
         return self.PrimitiveResult(category, status_code, description, rsp_ds)
 
     def _get_status_description(self, status_code):
+        """
+        Retrieves the description for a given status code.
+
+        This method retrieves the description associated with a given status
+        code from the GENERAL_STATUS dictionary. If the status code is not
+        found, it returns "Unknown".  This method is intended to be overridden
+        by subclasses to provide more specific status descriptions.
+
+        Args:
+            status_code (int): The status code to look up.
+
+        Returns:
+            str: The description of the status code.
+        """
         return GENERAL_STATUS.get(status_code, ("Unknown", "Unknown status code"))[1]
 
     def set_called_ae(self, called_ip: str, called_port: int, called_ae_title: str = None):
+        """
+        Sets the called AE parameters.
+
+        This method allows setting the called AE parameters (IP, port, and
+        AE title) after the BaseSCU object has been initialized.  It's
+        useful when the called AE information is not available during
+        object creation.
+
+        Args:
+            called_ip (str): The IP address of the called AE.
+            called_port (int): The port number of the called AE.
+            called_ae_title (str, optional): The AE title of the called AE.
+                Defaults to "ANY-SCP".
+        """
         self.called_ip = called_ip
         self.called_port = called_port
         if called_ae_title is None or called_ae_title == "":
@@ -245,7 +341,7 @@ class BaseSCU:
         PrimitiveResult:
             A named tuple containing the status category, status code, status description, and dataset.
         """
-        assoc_result = self._associate()
+        assoc_result = self._associate(required_sop_classes=[Verification])
 
         if assoc_result.status == "Error":
             return self.PrimitiveResult("AssocFailure", 0xD000, assoc_result.description, None)

--- a/tdwii_plus_examples/cli/storescu.py
+++ b/tdwii_plus_examples/cli/storescu.py
@@ -84,7 +84,7 @@ def main():
     parser.add_argument("ip", type=str, help="IP address or hotname of called AE")
     parser.add_argument("port", type=int, help="TCP port number of called AE")
     parser.add_argument(
-        "path", metavar="path", nargs="+", help="DICOM file or directory containing SOP instances to store", type=str
+        "path", metavar="path", nargs="*", help="DICOM file or directory containing SOP instances to store", type=str
     )
     parser.add_argument("-r", "--recurse", help="recursively search the given directory", action="store_true")
     parser.add_argument("-aet", "--ae_title", type=str, default="STORESCU", help="Application Entity Title")
@@ -95,6 +95,12 @@ def main():
     parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
 
     args = parser.parse_args()
+
+    if not args.echo and not args.path:
+        parser.error("Either -e/--echo or a path must be provided")
+
+    if args.echo and args.path:
+        print("Warning: Path argument is ignored when using -e/--echo option")
 
     if args.quiet:
         log_level = logging.CRITICAL
@@ -129,7 +135,7 @@ def main():
             print(f"Verification (C-ECHO) failed: {num_created_instances.status_description}")
 
     # UPS instances creation requested
-    elif args.path is not None:
+    elif args.path:
         valid_paths, invalid_paths = get_files(args.path, args.recurse)
 
         for path in invalid_paths:

--- a/tdwii_plus_examples/cli/upschangestatescu.py
+++ b/tdwii_plus_examples/cli/upschangestatescu.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""
+A DICOM UPS Pull Service Class User (SCU) application.
+
+This application implements a UPS Pull N-ACTION - Change UPS State SOP Class SCU.
+It uses the DIMSE N-ACTION Service to change the state of UPS instances on a remote SCP.
+
+Usage:
+    upschangestatescu [options] ip port ups_uid state [transaction_uid]
+
+Arguments:
+    ip              IP address of called AE
+    port            TCP port number of called AE
+    ups_uid         SOP Instance UID of the UPS instance
+    state           Requested procedure step state ("IN PROGRESS", "CANCELED", or "COMPLETED")
+    transaction_uid Transaction UID of the UPS (required if state is "CANCELED" or "COMPLETED")
+
+Options:
+    -h, --help               Show this help message and exit
+    -aet, --ae_title         Application Entity Title (default: UPSPULLSCU)
+    -aec, --called_ae_title  Called Application Entity Title (default: ANYSCP)
+    -e, --echo               Verification of DICOM connection with Called AET
+    -v, --verbose            Set log level to INFO
+    -d, --debug              Set log level to DEBUG
+    -q, --quiet              Suppress all log output
+"""
+
+import argparse
+import logging
+
+from tdwii_plus_examples.upspullnactionscu import UPSPullNActionSCU
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a DICOM UPS Push N-CREATE request")
+    parser.add_argument("ip", type=str, help="IP address or hotname of called AE")
+    parser.add_argument("port", type=int, help="TCP port number of called AE")
+    parser.add_argument("ups_uid", help="SOP Instance UID of the UPS", type=str)
+    parser.add_argument(
+        "state",
+        nargs="?",
+        choices=["IN PROGRESS", "CANCELED", "COMPLETED"],
+        default="IN PROGRESS",
+        help='Requested procedure step state (default: "IN PROGRESS")',
+    )
+    parser.add_argument(
+        "transaction_uid",
+        nargs="?",
+        type=str,
+        default=None,
+        help="Transaction UID of the UPS (required for CANCELED or COMPLETED)",
+    )
+
+    parser.add_argument("-aet", "--ae_title", type=str, default="UPSPULLSCU", help="Application Entity Title")
+    parser.add_argument("-aec", "--called_ae_title", type=str, default="ANYSCP", help="Called Application Entity Title")
+    parser.add_argument("-e", "--echo", action="store_true", help="Verification of DICOM connection with Called AET")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Set log level to INFO")
+    parser.add_argument("-d", "--debug", action="store_true", help="Set log level to DEBUG")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
+
+    args = parser.parse_args()
+
+    # Argument consistency checks
+    if not args.echo and not args.ups_uid:
+        parser.error("Either -e/--echo or a ups_uid must be provided")
+    if args.echo and args.ups_uid:
+        print("Warning: ups_uid argument is ignored when using -e/--echo option")
+    if args.state == "IN PROGRESS" and args.transaction_uid:
+        parser.error("transaction_uid should not be provided when state is IN PROGRESS")
+    if args.state in ("CANCELED", "COMPLETED") and not args.transaction_uid:
+        parser.error("transaction_uid argument is required when state is CANCELED or COMPLETED")
+
+    if args.quiet:
+        log_level = logging.CRITICAL
+    elif args.verbose:
+        log_level = logging.INFO
+    elif args.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.WARNING
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger("upspullnactionscu")
+    logger.setLevel(log_level)
+
+    logger.info(f"Initializing UPSPullNActionSCU instance with remote SCP {args.called_ae_title}@{args.ip}:{args.port}")
+    scu = UPSPullNActionSCU(
+        logger=logger,
+        calling_ae_title=args.ae_title,
+        called_ip=args.ip,
+        called_port=args.port,
+        called_ae_title=args.called_ae_title,
+    )
+
+    # Verification requested
+    if args.echo:
+        print("Verification (C-ECHO) request")
+        result = scu.verify()
+        if result.status_category == "Success":
+            print("Verification (C-ECHO) successful")
+        else:
+            print(f"Verification (C-ECHO) failed: {result.status_description}")
+
+    # UPS instances state change requested
+    elif args.ups_uid is not None:
+        ups_instance_uid = args.ups_uid
+        if args.state == "IN PROGRESS":
+            if args.transaction_uid:
+                parser.error("transaction_uid should not be provided when state is IN PROGRESS")
+            result = scu.claim_ups(ups_instance_uid)
+        elif args.state in ("CANCELED", "COMPLETED"):
+            if not args.transaction_uid:
+                parser.error("transaction_uid argument is required when state is CANCELED or COMPLETED")
+            if args.state == "CANCELED":
+                result = scu.cancel_ups(ups_instance_uid, args.transaction_uid)
+            else:
+                result = scu.complete_ups(ups_instance_uid, args.transaction_uid)
+        else:
+            parser.error(f"Unknown state: {args.state}")
+
+        if result:
+            print(f"Change UPS State to {args.state} successful")
+        else:
+            print("Change UPS State failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tdwii_plus_examples/cli/upschangestatescu.py
+++ b/tdwii_plus_examples/cli/upschangestatescu.py
@@ -27,6 +27,7 @@ Options:
 
 import argparse
 import logging
+import sys
 
 from tdwii_plus_examples.upspullnactionscu import UPSPullNActionSCU
 
@@ -100,6 +101,7 @@ def main():
             print("Verification (C-ECHO) successful")
         else:
             print(f"Verification (C-ECHO) failed: {result.status_description}")
+            sys.exit(1)
 
     # UPS instances state change requested
     elif args.ups_uid is not None:
@@ -120,8 +122,11 @@ def main():
 
         if result:
             print(f"Change UPS State to {args.state} successful")
+            if args.state == "IN PROGRESS":
+                print(f"Transaction UID: {result}")
         else:
             print("Change UPS State failed")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tdwii_plus_examples/cstorescu.py
+++ b/tdwii_plus_examples/cstorescu.py
@@ -102,10 +102,10 @@ class CStoreSCU(BaseSCU):
             int: The number of DICOM instances successfully stored.
         """
         required_sop_classes = [instance.SOPClassUID for instance in instances]
-        assoc_result = self._associate(required_sop_classes=required_sop_classes, verbose=False)
+        success, _ = self._associate(required_sop_classes=required_sop_classes)
         success_count = 0
 
-        if not assoc_result:
+        if not success:
             return 0
 
         for msg_id, instance in enumerate(instances, start=0):

--- a/tdwii_plus_examples/tests/cli/test_upschangestatescu.py
+++ b/tdwii_plus_examples/tests/cli/test_upschangestatescu.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from io import StringIO
 from unittest import mock
 
 import tdwii_plus_examples.cli.upschangestatescu as upschangestatescu
@@ -15,28 +16,33 @@ class TestUPSChangeStateSCUCLI(unittest.TestCase):
         self.scu_patch.stop()
 
     def run_main_with_args(self, args):
-        with mock.patch.object(sys, "argv", args):
+        with mock.patch.object(sys, "argv", args), mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             try:
                 upschangestatescu.main()
             except SystemExit as e:
-                return e.code
-            return 0
+                return e.code, mock_stdout.getvalue()
+            return 0, mock_stdout.getvalue()
 
     def test_claim_ups_success(self):
         self.mock_scu.claim_ups.return_value = "1.2.3.4"
-        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "IN PROGRESS"])
+        exit_code, output = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "IN PROGRESS"])
         self.mock_scu.claim_ups.assert_called_once_with("1.2.3.4.5")
         self.assertEqual(exit_code, 0)
+        self.assertIn("Transaction UID: 1.2.3.4", output)
 
     def test_cancel_ups_success(self):
         self.mock_scu.cancel_ups.return_value = True
-        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "CANCELED", "2.3.4.5.6"])
+        exit_code, output = self.run_main_with_args(
+            ["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "CANCELED", "2.3.4.5.6"]
+        )
         self.mock_scu.cancel_ups.assert_called_once_with("1.2.3.4.5", "2.3.4.5.6")
         self.assertEqual(exit_code, 0)
 
     def test_complete_ups_success(self):
         self.mock_scu.complete_ups.return_value = True
-        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "COMPLETED", "2.3.4.5.6"])
+        exit_code, output = self.run_main_with_args(
+            ["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "COMPLETED", "2.3.4.5.6"]
+        )
         self.mock_scu.complete_ups.assert_called_once_with("1.2.3.4.5", "2.3.4.5.6")
         self.assertEqual(exit_code, 0)
 
@@ -44,7 +50,7 @@ class TestUPSChangeStateSCUCLI(unittest.TestCase):
         with mock.patch.object(sys, "argv", ["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "CANCELED"]):
             with self.assertRaises(SystemExit) as cm:
                 upschangestatescu.main()
-            self.assertNotEqual(cm.exception.code, 0)
+            self.assertEqual(cm.exception.code, 2)  # parser error code value
 
     def test_transaction_uid_given_for_in_progress(self):
         with mock.patch.object(
@@ -52,16 +58,16 @@ class TestUPSChangeStateSCUCLI(unittest.TestCase):
         ):
             with self.assertRaises(SystemExit) as cm:
                 upschangestatescu.main()
-            self.assertNotEqual(cm.exception.code, 0)
+            self.assertEqual(cm.exception.code, 2)  # parser error code value
 
     def test_echo_success(self):
         self.mock_scu.verify.return_value = mock.Mock(status_category="Success")
-        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
+        exit_code, output = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
         self.mock_scu.verify.assert_called_once()
         self.assertEqual(exit_code, 0)
 
     def test_echo_failure(self):
         self.mock_scu.verify.return_value = mock.Mock(status_category="Failure", status_description="Failed")
-        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
+        exit_code, output = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
         self.mock_scu.verify.assert_called_once()
-        self.assertEqual(exit_code, 0)
+        self.assertEqual(exit_code, 1)

--- a/tdwii_plus_examples/tests/cli/test_upschangestatescu.py
+++ b/tdwii_plus_examples/tests/cli/test_upschangestatescu.py
@@ -1,0 +1,67 @@
+import sys
+import unittest
+from unittest import mock
+
+import tdwii_plus_examples.cli.upschangestatescu as upschangestatescu
+
+
+class TestUPSChangeStateSCUCLI(unittest.TestCase):
+    def setUp(self):
+        self.scu_patch = mock.patch("tdwii_plus_examples.cli.upschangestatescu.UPSPullNActionSCU")
+        self.mock_scu_class = self.scu_patch.start()
+        self.mock_scu = self.mock_scu_class.return_value
+
+    def tearDown(self):
+        self.scu_patch.stop()
+
+    def run_main_with_args(self, args):
+        with mock.patch.object(sys, "argv", args):
+            try:
+                upschangestatescu.main()
+            except SystemExit as e:
+                return e.code
+            return 0
+
+    def test_claim_ups_success(self):
+        self.mock_scu.claim_ups.return_value = "1.2.3.4"
+        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "IN PROGRESS"])
+        self.mock_scu.claim_ups.assert_called_once_with("1.2.3.4.5")
+        self.assertEqual(exit_code, 0)
+
+    def test_cancel_ups_success(self):
+        self.mock_scu.cancel_ups.return_value = True
+        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "CANCELED", "2.3.4.5.6"])
+        self.mock_scu.cancel_ups.assert_called_once_with("1.2.3.4.5", "2.3.4.5.6")
+        self.assertEqual(exit_code, 0)
+
+    def test_complete_ups_success(self):
+        self.mock_scu.complete_ups.return_value = True
+        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "COMPLETED", "2.3.4.5.6"])
+        self.mock_scu.complete_ups.assert_called_once_with("1.2.3.4.5", "2.3.4.5.6")
+        self.assertEqual(exit_code, 0)
+
+    def test_missing_transaction_uid_for_cancel(self):
+        with mock.patch.object(sys, "argv", ["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "CANCELED"]):
+            with self.assertRaises(SystemExit) as cm:
+                upschangestatescu.main()
+            self.assertNotEqual(cm.exception.code, 0)
+
+    def test_transaction_uid_given_for_in_progress(self):
+        with mock.patch.object(
+            sys, "argv", ["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "IN PROGRESS", "2.3.4.5.6"]
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                upschangestatescu.main()
+            self.assertNotEqual(cm.exception.code, 0)
+
+    def test_echo_success(self):
+        self.mock_scu.verify.return_value = mock.Mock(status_category="Success")
+        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
+        self.mock_scu.verify.assert_called_once()
+        self.assertEqual(exit_code, 0)
+
+    def test_echo_failure(self):
+        self.mock_scu.verify.return_value = mock.Mock(status_category="Failure", status_description="Failed")
+        exit_code = self.run_main_with_args(["upschangestatescu", "127.0.0.1", "11114", "1.2.3.4.5", "--echo"])
+        self.mock_scu.verify.assert_called_once()
+        self.assertEqual(exit_code, 0)

--- a/tdwii_plus_examples/tests/test_cstorescu_integration.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_integration.py
@@ -55,11 +55,6 @@ class TestCStoreSCU(unittest.TestCase):
         )
 
     def tearDown(self):
-        # Remove the temporary directory and its contents
-        files_in_temp_dir = os.listdir(self.temp_dir)
-        shutil.rmtree(self.temp_dir)
-        self.test_logger.info(f"Removed the temp directory: {self.temp_dir} and its contents: {files_in_temp_dir}")
-
         # Try to gracefully terminate the process.
         self.test_logger.info(f"Terminating process with PID: {self.process.pid}")
         try:
@@ -90,6 +85,11 @@ class TestCStoreSCU(unittest.TestCase):
             # Ensure the stdout thread has finished
             if self.stdout_thread:
                 self.stdout_thread.join(timeout=1.0)
+
+        # Remove the temporary directory and its contents
+        files_in_temp_dir = os.listdir(self.temp_dir)
+        shutil.rmtree(self.temp_dir)
+        self.test_logger.info(f"Removed the temp directory: {self.temp_dir} and its contents: {files_in_temp_dir}")
 
         # Remove and close the memory handler for scu and test loggers
         for logger, handler in [(self.scu_logger, self.memory_handler), (self.test_logger, self.stream_handler)]:

--- a/tdwii_plus_examples/tests/test_cstorescu_integration.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_integration.py
@@ -99,7 +99,8 @@ class TestCStoreSCU(unittest.TestCase):
     @parameterized.expand(
         [
             ("all_contexts_accepted", "SecondaryCaptureImageStorage,CTImageStorage", 3),
-            ("some_contexts_rejected", "CTImageStorage", 0),
+            ("required_contexts_rejected", "CTImageStorage", 0),
+            ("non_required_contexts_rejected", "SecondaryCaptureImageStorage", 3),
         ]
     )
     def test_verif_storage(self, name, supported_contexts, expected_success_count):

--- a/tdwii_plus_examples/tests/test_cstorescu_unit.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_unit.py
@@ -3,8 +3,14 @@ import unittest
 from unittest import mock
 
 from pydicom import Dataset
-from pydicom.uid import UID, generate_uid
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 from pynetdicom.presentation import build_context
+from pynetdicom.sop_class import (
+    CTImageStorage,
+    MRImageStorage,
+    SecondaryCaptureImageStorage,
+    StudyRootQueryRetrieveInformationModelFind,
+)
 
 from tdwii_plus_examples.cstorescu import CStoreSCU
 
@@ -30,9 +36,9 @@ class TestCStoreSCU(unittest.TestCase):
         """Test storing multiple DICOM instances."""
         # Create 2 empty instances
         ds_1 = Dataset()
-        ds_1.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds_1.SOPClassUID = CTImageStorage
         ds_2 = Dataset()
-        ds_2.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds_2.SOPClassUID = CTImageStorage
         instances = [ds_1, ds_2]
 
         # Mock the association instance
@@ -42,7 +48,7 @@ class TestCStoreSCU(unittest.TestCase):
         # Mock the send_c_store method to return a success status
         mock_assoc_instance.send_c_store.return_value = Dataset()
         # Mock _associate to return the mock association instance
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         # Assign the mock association instance to the SCU's assoc attribute
         self.cstore_scu.assoc = mock_assoc_instance
         # Mock the _handle_response method to return a success status
@@ -62,10 +68,10 @@ class TestCStoreSCU(unittest.TestCase):
         """Test storing multiple DICOM instances with partial success."""
         # Create 2 minimal DICOM instances
         ds_1 = Dataset()
-        ds_1.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds_1.SOPClassUID = CTImageStorage
         ds_1.SOPInstanceUID = generate_uid()
         ds_2 = Dataset()
-        ds_2.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds_2.SOPClassUID = CTImageStorage
         ds_2.SOPInstanceUID = generate_uid()
         instances = [ds_1, ds_2]
 
@@ -76,7 +82,7 @@ class TestCStoreSCU(unittest.TestCase):
         # Mock the send_c_store method to return a success status
         mock_assoc_instance.send_c_store.return_value = Dataset()
         # Mock _associate to return the mock association instance
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         # Assign the mock association instance to the SCU's assoc attribute
         self.cstore_scu.assoc = mock_assoc_instance
         # Set up side_effect for mock_handle_response to return different statuses
@@ -99,7 +105,7 @@ class TestCStoreSCU(unittest.TestCase):
         """Test storing instances with association failure."""
         # Create 1 'valid' DICOM instance
         ds = Dataset()
-        ds.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage SOP Class UID
+        ds.SOPClassUID = CTImageStorage
         ds.SOPInstanceUID = generate_uid()
         instances = [ds]
 
@@ -111,7 +117,7 @@ class TestCStoreSCU(unittest.TestCase):
         # Mock the association result to simulate an association failure
         mock_assoc_result = mock.Mock()
         mock_assoc_result = False
-        mock_associate.return_value = mock_assoc_result
+        mock_associate.return_value = False, mock_assoc_result
 
         # Call the method
         success_count = self.cstore_scu.store_instances(instances)
@@ -124,16 +130,16 @@ class TestCStoreSCU(unittest.TestCase):
         """Test that required SOP classes are correctly extracted from instances."""
         # Create instances with different SOP Class UIDs
         ds1 = Dataset()
-        ds1.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.2")  # CT Image Storage
+        ds1.SOPClassUID = CTImageStorage
         ds2 = Dataset()
-        ds2.SOPClassUID = UID("1.2.840.10008.5.1.4.1.1.4")  # MR Image Storage
+        ds2.SOPClassUID = MRImageStorage
         instances = [ds1, ds2]
 
         # Mock the association result
         mock_assoc_result = mock.Mock()
         mock_assoc_result.status = True  # Assume successful association for this test
         mock_assoc_result.accepted_sop_classes = [ds1.SOPClassUID, ds2.SOPClassUID]  # Mock accepted SOP classes
-        mock_associate.return_value = mock_assoc_result
+        mock_associate.return_value = (True, mock_assoc_result)
 
         # Mock the association and release method
         self.cstore_scu.assoc = mock.Mock()
@@ -151,14 +157,14 @@ class TestCStoreSCU(unittest.TestCase):
 
         # Assert that _associate was called with the correct required_sop_classes
         expected_required_sop_classes = [ds1.SOPClassUID, ds2.SOPClassUID]
-        mock_associate.assert_called_once_with(required_sop_classes=expected_required_sop_classes, verbose=False)
+        mock_associate.assert_called_once_with(required_sop_classes=expected_required_sop_classes)
 
     def test_set_contexts_valid(self):
         """Test set_contexts."""
         # Valid contexts
         storage_contexts = [
-            build_context("1.2.840.10008.5.1.4.1.1.2"),  # CT Image Storage
-            build_context("1.2.840.10008.5.1.4.1.1.4"),  # MR Image Storage
+            build_context(MRImageStorage),
+            build_context(MRImageStorage),
         ]
         self.cstore_scu.set_contexts(storage_contexts)
         self.assertEqual(len(self.cstore_scu.contexts), 2)
@@ -168,7 +174,7 @@ class TestCStoreSCU(unittest.TestCase):
 
     def test_set_contexts_invalid(self):
         """Test set_contexts with an invalid context."""
-        qr_abstract__syntax = "1.2.840.10008.5.1.4.1.2.2.1"  # not a storage context
+        qr_abstract__syntax = StudyRootQueryRetrieveInformationModelFind  # not a storage context
         invalid_context = build_context(qr_abstract__syntax)
 
         with self.assertRaisesRegex(
@@ -180,16 +186,16 @@ class TestCStoreSCU(unittest.TestCase):
         """Test set_contexts_from_files."""
         # Create some dummy datasets
         ds1 = Dataset()
-        ds1.SOPClassUID = "1.2.840.10008.5.1.4.1.1.2"  # CT Image Storage
+        ds1.SOPClassUID = CTImageStorage
         ds2 = Dataset()
-        ds2.SOPClassUID = "1.2.840.10008.5.1.4.1.1.4"  # MR Image Storage
+        ds2.SOPClassUID = MRImageStorage
         instances = [ds1, ds2]
 
         self.cstore_scu.set_contexts_from_files(instances)
 
         self.assertEqual(len(self.cstore_scu.contexts), 2)
-        self.assertIn(build_context(ds1.SOPClassUID, "1.2.840.10008.1.2.1"), self.cstore_scu.contexts)
-        self.assertIn(build_context(ds2.SOPClassUID, "1.2.840.10008.1.2.1"), self.cstore_scu.contexts)
+        self.assertIn(build_context(ds1.SOPClassUID, ExplicitVRLittleEndian), self.cstore_scu.contexts)
+        self.assertIn(build_context(ds2.SOPClassUID, ExplicitVRLittleEndian), self.cstore_scu.contexts)
         # Check if requested contexts were updated (including verification)
         self.assertEqual(len(self.cstore_scu.ae.requested_contexts), 3)
 
@@ -199,12 +205,12 @@ class TestCStoreSCU(unittest.TestCase):
 
     def test_validate_contexts_valid(self):
         """Test _validate_contexts with valid contexts."""
-        storage_contexts = [build_context(uid) for uid in ["1.2.840.10008.5.1.4.1.1.2", "1.2.840.10008.5.1.4.1.1.7"]]
+        storage_contexts = [build_context(uid) for uid in [CTImageStorage, SecondaryCaptureImageStorage]]
         self.assertEqual(self.cstore_scu._validate_contexts(storage_contexts), storage_contexts)
 
     def test_validate_contexts_invalid(self):
         """Test _validate_contexts with invalid contexts."""
-        qr_abstract__syntax = "1.2.840.10008.5.1.4.1.2.2.1"  # not a storage context
+        qr_abstract__syntax = StudyRootQueryRetrieveInformationModelFind  # not a storage context
         contexts = [build_context(qr_abstract__syntax)]
         with self.assertRaisesRegex(
             ValueError, f"Only Storage Presentation Contexts are allowed. Invalid contexts: \\['{qr_abstract__syntax}'\\]"

--- a/tdwii_plus_examples/tests/test_cstorescu_unit.py
+++ b/tdwii_plus_examples/tests/test_cstorescu_unit.py
@@ -174,11 +174,11 @@ class TestCStoreSCU(unittest.TestCase):
 
     def test_set_contexts_invalid(self):
         """Test set_contexts with an invalid context."""
-        qr_abstract__syntax = StudyRootQueryRetrieveInformationModelFind  # not a storage context
-        invalid_context = build_context(qr_abstract__syntax)
+        qr_abstract_syntax = StudyRootQueryRetrieveInformationModelFind  # not a storage context
+        invalid_context = build_context(qr_abstract_syntax)
 
         with self.assertRaisesRegex(
-            ValueError, f"Only Storage Presentation Contexts are allowed. Invalid contexts: \\['{qr_abstract__syntax}'\\]"
+            ValueError, f"Only Storage Presentation Contexts are allowed. Invalid contexts: \\['{qr_abstract_syntax}'\\]"
         ):
             self.cstore_scu.set_contexts([invalid_context])
 

--- a/tdwii_plus_examples/tests/test_upspullnactionscu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspullnactionscu_integration.py
@@ -55,11 +55,6 @@ class TestUPSPullNActionSCUIntegration(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Remove the temporary directory and its contents
-        files_in_temp_dir = os.listdir(cls.temp_dir)
-        shutil.rmtree(cls.temp_dir)
-        cls.test_logger.info(f"Removed the temp directory: {cls.temp_dir} and its contents: {files_in_temp_dir}")
-
         # Try to gracefully terminate the process.
         cls.test_logger.info(f"Terminating process with PID: {cls.process.pid}")
         try:
@@ -90,6 +85,11 @@ class TestUPSPullNActionSCUIntegration(unittest.TestCase):
             # Ensure the stdout thread has finished
             if cls.stdout_thread:
                 cls.stdout_thread.join(timeout=1.0)
+
+        # Remove the temporary directory and its contents
+        files_in_temp_dir = os.listdir(cls.temp_dir)
+        shutil.rmtree(cls.temp_dir)
+        cls.test_logger.info(f"Removed the temp directory: {cls.temp_dir} and its contents: {files_in_temp_dir}")
 
         # Remove and close the memory handler for scu and test loggers
         for logger, handler in [(cls.scu_logger, cls.memory_handler), (cls.test_logger, cls.stream_handler)]:

--- a/tdwii_plus_examples/tests/test_upspullnactionscu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspullnactionscu_integration.py
@@ -1,0 +1,171 @@
+import logging
+import os
+import shutil
+import signal
+import tempfile
+import unittest
+from logging.handlers import MemoryHandler
+from subprocess import TimeoutExpired
+
+import psutil
+
+from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_ups
+from tdwii_plus_examples.tests.utils.utils import get_configured_logger, start_scp
+from tdwii_plus_examples.upspullnactionscu import UPSPullNActionSCU
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
+
+
+class TestUPSPullNActionSCUIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Set up the logger for the UPSPullNActionSCU to DEBUG level
+        # with a memory handler to store up to 100 log messages
+        cls.scu_logger, cls.memory_handler = get_configured_logger(
+            "upspullnactionscu", level=logging.DEBUG, handler_class=MemoryHandler, capacity=100
+        )
+
+        # Set up the logger for this test to DEBUG level
+        cls.test_logger, cls.stream_handler = get_configured_logger("test_upspullnactionscu", level=logging.DEBUG)
+
+        # Create a temporary directory for UPSSCP staging area
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.test_logger.info(f"{cls.temp_dir} directory created")
+
+        # Start the UPS SCP Server (replace with your actual SCP command)
+        command = [
+            "./tdwii_plus_examples/cli/upsscp/upsscp.py",
+            "-v",
+            "--database-location",
+            f"{cls.temp_dir}/test.sqlite",
+            "--instance-location",
+            cls.temp_dir,
+        ]
+
+        cls.upsscp_started, cls.process, cls.stdout_thread = start_scp(command, cls.test_logger)
+        cls.test_logger.info(f"Started process with PID: {cls.process.pid}")
+
+        # Create the UPSPullNActionSCU instance
+        cls.scu = UPSPullNActionSCU(
+            calling_ae_title="UPSPULLSCU",
+            called_ae_title="ANYSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=cls.scu_logger,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the temporary directory and its contents
+        files_in_temp_dir = os.listdir(cls.temp_dir)
+        shutil.rmtree(cls.temp_dir)
+        cls.test_logger.info(f"Removed the temp directory: {cls.temp_dir} and its contents: {files_in_temp_dir}")
+
+        # Try to gracefully terminate the process.
+        cls.test_logger.info(f"Terminating process with PID: {cls.process.pid}")
+        try:
+            cls.process.terminate()
+            cls.process.wait(timeout=1)
+            cls.test_logger.info("Process terminated gracefully.")
+        except (ChildProcessError, TimeoutExpired):
+            cls.test_logger.warning("Process termination timed out or process already finished.")
+
+        # Try to kill child processes.
+        try:
+            parent = psutil.Process(cls.process.pid)
+            for child in parent.children(recursive=True):
+                child.kill()
+            cls.test_logger.info("Child processes terminated.")
+        except psutil.NoSuchProcess:
+            cls.test_logger.warning("Error killing subprocesses. Parent process not found. Probably already terminated.")
+
+        # Try to forcefully kill the process.
+        try:
+            os.kill(cls.process.pid, signal.SIGKILL)
+            cls.process.wait(timeout=1)  # Ensure process termination
+            cls.test_logger.info("Process forcefully terminated.")
+        except OSError:
+            cls.test_logger.warning("Error killing process. Probably already terminated.")
+
+        finally:
+            # Ensure the stdout thread has finished
+            if cls.stdout_thread:
+                cls.stdout_thread.join(timeout=1.0)
+
+        # Remove and close the memory handler for scu and test loggers
+        for logger, handler in [(cls.scu_logger, cls.memory_handler), (cls.test_logger, cls.stream_handler)]:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_claim_and_complete_ups(self):
+        """Integration test for claiming and completing a UPS instance."""
+
+        if not self.upsscp_started:
+            self.fail("upsscp server failed to start.")
+            return
+
+        # Create a UPS in the SCP
+        ups_instance = generate_ups()
+        scu = UPSPushNCreateSCU(
+            calling_ae_title="UPSPUSH",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=self.scu_logger,
+        )
+        num_created_instances = scu.create_ups_instances([ups_instance])
+
+        if num_created_instances != 1:
+            self.fail("failed to create UPS.")
+            return
+
+        sop_instance_uid = ups_instance.SOPInstanceUID
+
+        # Try to claim the UPS
+        transaction_uid = self.scu.claim_ups(sop_instance_uid)
+        self.assertIsNotNone(transaction_uid)
+        self.test_logger.info(f"Claimed UPS with transaction UID: {transaction_uid}")
+
+        # Try to complete the UPS if it was claimed
+        if transaction_uid:
+            result = self.scu.complete_ups(sop_instance_uid, transaction_uid)
+            self.assertTrue(result)
+            self.test_logger.info("Completed UPS successfully.")
+
+    def test_claim_and_cancel_ups(self):
+        """Integration test for claiming and completing a UPS instance."""
+
+        if not self.upsscp_started:
+            self.fail("upsscp server failed to start.")
+            return
+
+        # Create a UPS in the SCP
+        ups_instance = generate_ups()
+        scu = UPSPushNCreateSCU(
+            calling_ae_title="UPSPUSH",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=self.scu_logger,
+        )
+        num_created_instances = scu.create_ups_instances([ups_instance])
+
+        if num_created_instances != 1:
+            self.fail("failed to create UPS.")
+            return
+
+        sop_instance_uid = ups_instance.SOPInstanceUID
+
+        # Try to claim the UPS
+        transaction_uid = self.scu.claim_ups(sop_instance_uid)
+        self.assertIsNotNone(transaction_uid)
+        self.test_logger.info(f"Claimed UPS with transaction UID: {transaction_uid}")
+
+        # Try to complete the UPS if it was claimed
+        if transaction_uid:
+            result = self.scu.cancel_ups(sop_instance_uid, transaction_uid)
+            self.assertTrue(result)
+            self.test_logger.info("Canceled UPS successfully.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/test_upspullnactionscu_unit.py
+++ b/tdwii_plus_examples/tests/test_upspullnactionscu_unit.py
@@ -41,7 +41,7 @@ class TestUPSPullNActionSCU(unittest.TestCase):
         # Mock the send_n_action method to return a tuple of (status, dataset)
         mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
         # Mock _associate to return the mock association instance
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         # Assign the mock association instance to the SCU's assoc attribute
         self.scu.assoc = mock_assoc_instance
         # Mock the _handle_response method return value status
@@ -82,7 +82,7 @@ class TestUPSPullNActionSCU(unittest.TestCase):
         mock_assoc_instance = mock.Mock()
         mock_assoc_instance.release = mock.Mock()
         mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         self.scu.assoc = mock_assoc_instance
         mock_handle_response.return_value = mock.Mock(status_category=status_category)
 
@@ -112,7 +112,7 @@ class TestUPSPullNActionSCU(unittest.TestCase):
         mock_assoc_instance = mock.Mock()
         mock_assoc_instance.release = mock.Mock()
         mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         self.scu.assoc = mock_assoc_instance
         mock_handle_response.return_value = mock.Mock(status_category=status_category)
 
@@ -154,7 +154,7 @@ class TestUPSPullNActionSCU(unittest.TestCase):
             mock_assoc_instance = mock.Mock()
             mock_assoc_instance.release = mock.Mock()
             mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
-            mock_associate.return_value = mock_assoc_instance
+            mock_associate.return_value = True, mock_assoc_instance
             self.scu.assoc = mock_assoc_instance
             mock_handle_response.return_value = mock.Mock(status_category="Success")
 

--- a/tdwii_plus_examples/tests/test_upspullnactionscu_unit.py
+++ b/tdwii_plus_examples/tests/test_upspullnactionscu_unit.py
@@ -1,0 +1,165 @@
+import logging
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+from pydicom import Dataset
+from pydicom.uid import generate_uid
+
+from tdwii_plus_examples.upspullnactionscu import UPSPullNActionSCU
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestUPSPullNActionSCU(unittest.TestCase):
+    def setUp(self):
+        """Setup before each test."""
+        # Create UPSPullNActionSCU instance
+        self.scu = UPSPullNActionSCU(
+            calling_ae_title="CALLING_AE",
+            called_ip="127.0.0.1",
+            called_port=11112,
+            called_ae_title="CALLED_AE",
+            logger=LOGGER,
+        )
+
+    @parameterized.expand(
+        [
+            ("success", "Success", True),
+            ("failure", "Failure", False),
+        ]
+    )
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._associate")
+    def test_claim_ups(self, name, status_category, expected, mock_associate, mock_handle_response):
+        """Test claiming a UPS with parameterized status_category."""
+
+        # Mock the association instance
+        mock_assoc_instance = mock.Mock()
+        # Mock the release method
+        mock_assoc_instance.release = mock.Mock()
+        # Mock the send_n_action method to return a tuple of (status, dataset)
+        mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
+        # Mock _associate to return the mock association instance
+        mock_associate.return_value = mock_assoc_instance
+        # Assign the mock association instance to the SCU's assoc attribute
+        self.scu.assoc = mock_assoc_instance
+        # Mock the _handle_response method return value status
+        mock_handle_response.return_value = mock.Mock(status_category=status_category)
+
+        sop_instance_uid = generate_uid()
+        transaction_uid = self.scu.claim_ups(sop_instance_uid)
+
+        # Check if transaction UID is generated and stored
+        if expected:
+            # On success, transaction_uid should be stored and not None
+            self.assertIsNotNone(transaction_uid)
+            self.assertEqual(self.scu.ups_transaction_info[sop_instance_uid], transaction_uid)
+        else:
+            # On failure, transaction_uid should be None and not stored
+            self.assertIsNone(transaction_uid)
+            self.assertNotIn(sop_instance_uid, self.scu.ups_transaction_info)
+
+        # Assert _associate was called
+        mock_associate.assert_called_once()
+        # Assert send_n_action was called
+        self.assertTrue(mock_assoc_instance.send_n_action.called)
+        # Assert _handle_response was called
+        mock_handle_response.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("success", "Success", True),
+            ("failure", "Failure", False),
+        ]
+    )
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._associate")
+    def test_complete_ups(self, name, status_category, expected, mock_associate, mock_handle_response):
+        """Test completing a UPS with parameterized status_category."""
+
+        # Mock the association instance
+        mock_assoc_instance = mock.Mock()
+        mock_assoc_instance.release = mock.Mock()
+        mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
+        mock_associate.return_value = mock_assoc_instance
+        self.scu.assoc = mock_assoc_instance
+        mock_handle_response.return_value = mock.Mock(status_category=status_category)
+
+        sop_instance_uid = generate_uid()
+        transaction_uid = generate_uid()
+        self.scu.ups_transaction_info[sop_instance_uid] = transaction_uid
+
+        result = self.scu.complete_ups(sop_instance_uid, transaction_uid)
+
+        self.assertEqual(result, expected)
+        mock_associate.assert_called_once()
+        self.assertTrue(mock_assoc_instance.send_n_action.called)
+        mock_handle_response.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("success", "Success", True),
+            ("failure", "Failure", False),
+        ]
+    )
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._associate")
+    def test_cancel_ups(self, name, status_category, expected, mock_associate, mock_handle_response):
+        """Test canceling a UPS with parameterized status_category."""
+
+        # Mock the association instance
+        mock_assoc_instance = mock.Mock()
+        mock_assoc_instance.release = mock.Mock()
+        mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
+        mock_associate.return_value = mock_assoc_instance
+        self.scu.assoc = mock_assoc_instance
+        mock_handle_response.return_value = mock.Mock(status_category=status_category)
+
+        sop_instance_uid = generate_uid()
+        transaction_uid = generate_uid()
+        self.scu.ups_transaction_info[sop_instance_uid] = transaction_uid
+
+        result = self.scu.cancel_ups(sop_instance_uid, transaction_uid)
+
+        self.assertEqual(result, expected)
+        mock_associate.assert_called_once()
+        self.assertTrue(mock_assoc_instance.send_n_action.called)
+        mock_handle_response.assert_called_once()
+
+    def test_complete_ups_missing_transaction_uid(self):
+        """Test complete_ups when transaction_uid is missing from ups_transaction_info and not passed as arg."""
+        sop_instance_uid = generate_uid()
+        # Do not set transaction_uid in ups_transaction_info
+
+        with (
+            mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._handle_response") as mock_handle_response,
+            mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._associate") as mock_associate,
+        ):
+            result = self.scu.complete_ups(sop_instance_uid)
+            self.assertFalse(result)
+            mock_associate.assert_not_called()
+            mock_handle_response.assert_not_called()
+
+    def test_complete_ups_transaction_uid_passed_as_arg(self):
+        """Test complete_ups when transaction_uid is not in ups_transaction_info but is passed as an argument."""
+        sop_instance_uid = generate_uid()
+        transaction_uid = generate_uid()
+        # Do not set transaction_uid in ups_transaction_info
+
+        with (
+            mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._handle_response") as mock_handle_response,
+            mock.patch("tdwii_plus_examples.upspullnactionscu.UPSPullNActionSCU._associate") as mock_associate,
+        ):
+            mock_assoc_instance = mock.Mock()
+            mock_assoc_instance.release = mock.Mock()
+            mock_assoc_instance.send_n_action.return_value = (Dataset(), Dataset())
+            mock_associate.return_value = mock_assoc_instance
+            self.scu.assoc = mock_assoc_instance
+            mock_handle_response.return_value = mock.Mock(status_category="Success")
+
+            result = self.scu.complete_ups(sop_instance_uid, transaction_uid)
+            self.assertTrue(result)
+            mock_associate.assert_called_once()
+            self.assertTrue(mock_assoc_instance.send_n_action.called)
+            mock_handle_response.assert_called_once()

--- a/tdwii_plus_examples/tests/test_upspushncreatescu_unit.py
+++ b/tdwii_plus_examples/tests/test_upspushncreatescu_unit.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from pydicom import Dataset
 from pydicom.uid import UID, generate_uid
+from pynetdicom.sop_class import UnifiedProcedureStepPush
 
 from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
 
@@ -29,10 +30,10 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         """Test creating multiple valid UPS instances."""
         # Create 2 'valid' UPS instances
         ds_1 = Dataset()
-        ds_1.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds_1.SOPClassUID = UnifiedProcedureStepPush
         ds_1.SOPInstanceUID = generate_uid()
         ds_2 = Dataset()
-        ds_2.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds_2.SOPClassUID = UnifiedProcedureStepPush
         ds_2.SOPInstanceUID = generate_uid()
         instances = [ds_1, ds_2]
 
@@ -43,7 +44,7 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         # Mock the send_n_create method to return a success status and an empty dataset.
         mock_assoc_instance.send_n_create.return_value = (Dataset(), Dataset())
         # Mock _associate to return the mock association instance, preventing a real association.
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = True, mock_assoc_instance
         # Assign the mock association instance to the SCU's assoc attribute.
         self.upspush_ncreate_scu.assoc = mock_assoc_instance
         # Mock the _handle_response method to return a success status.
@@ -78,7 +79,7 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         """Test creating UPS instances with association failure."""
         # Create 1 'valid' UPS instance
         ds = Dataset()
-        ds.SOPClassUID = UID("1.2.840.10008.5.1.4.34.6.1")  # UPS Push SOP Class UID
+        ds.SOPClassUID = UnifiedProcedureStepPush
         ds.SOPInstanceUID = generate_uid()
         instances = [ds]
 
@@ -87,7 +88,7 @@ class TestUPSPushNCreateSCU(unittest.TestCase):
         # Mock the release method.
         mock_assoc_instance.release = mock.Mock()
         # Mock _associate to return the mock association instance, preventing a real association.
-        mock_associate.return_value = mock_assoc_instance
+        mock_associate.return_value = False, mock_assoc_instance
         # Set the status to "Error" to simulate an association failure.
         mock_assoc_instance.status = "Error"
 

--- a/tdwii_plus_examples/tests/test_upswatchnactionscu_unit.py
+++ b/tdwii_plus_examples/tests/test_upswatchnactionscu_unit.py
@@ -159,14 +159,17 @@ class TestUPSWatchNActionSCU(unittest.TestCase):
         # Patch the _associate method with the appropriate result
         with patch(
             "tdwii_plus_examples.basescu.BaseSCU._associate",
-            return_value=UPSWatchNActionSCU.AssociationResult(
-                status=assoc_status,
-                description="Some SOP classes were refused"
-                if assoc_status == "Warning"
-                else "Association error"
-                if assoc_status == "Error"
-                else "Association successful",
-                accepted_sop_classes=accepted_sop_classes,
+            return_value=(
+                assoc_status == "Success",
+                UPSWatchNActionSCU.AssociationResult(
+                    status=assoc_status,
+                    description="Some SOP classes were refused"
+                    if assoc_status == "Warning"
+                    else "Association error"
+                    if assoc_status == "Error"
+                    else "Association successful",
+                    accepted_sop_classes=accepted_sop_classes,
+                ),
             ),
         ) as mock_associate:
             # Call the _toggle_subscription method

--- a/tdwii_plus_examples/upspullnactionscu.py
+++ b/tdwii_plus_examples/upspullnactionscu.py
@@ -3,10 +3,8 @@ from pydicom.uid import UID, generate_uid
 from pynetdicom.sop_class import UnifiedProcedureStepPull, UnifiedProcedureStepPush
 from pynetdicom.status import UNIFIED_PROCEDURE_STEP_SERVICE_CLASS_STATUS
 
+from tdwii_plus_examples._ups_action_type_id import UPSActionTypeID
 from tdwii_plus_examples.basescu import BaseSCU
-
-# Action Type ID constants
-ACTION_TYPE_ID_CHANGEUPSSTATE = 1
 
 # UPS Procedure Step State constants
 SCHEDULED: str = "SCHEDULED"
@@ -194,20 +192,20 @@ class UPSPullNActionSCU(BaseSCU):
             status description, and response dataset.
         """
         # Establish association with the SCP
-        assoc_result = self._associate(required_sop_classes=[UnifiedProcedureStepPull])
+        success, details = self._associate(required_sop_classes=[UnifiedProcedureStepPull])
 
-        if assoc_result.status == "Error":
-            return self.PrimitiveResult("AssocFailure", 0xD000, assoc_result.description, None)
+        if details.status == "Error":
+            return self.PrimitiveResult("AssocFailure", 0xD000, details.description, None)
 
-        if assoc_result.status == "Warning":
-            accepted_sop_names = [f"[{UID(uid).name}]" for uid in assoc_result.accepted_sop_classes]
-            self.logger.warning(f"{assoc_result.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
+        if details.status == "Warning":
+            accepted_sop_names = [f"[{UID(uid).name}]" for uid in details.accepted_sop_classes]
+            self.logger.warning(f"{details.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
 
         # Send the N-ACTION request
         self.logger.debug(f"Sending N-ACTION request for SOP Instance UID: {sop_instance_uid}")
         rsp_status, action_reply = self.assoc.send_n_action(
             dataset=action_info,
-            action_type=ACTION_TYPE_ID_CHANGEUPSSTATE,
+            action_type=UPSActionTypeID.CHANGE_UPS_STATE.value,
             class_uid=UnifiedProcedureStepPull,
             instance_uid=sop_instance_uid,
             meta_uid=UnifiedProcedureStepPush,

--- a/tdwii_plus_examples/upspullnactionscu.py
+++ b/tdwii_plus_examples/upspullnactionscu.py
@@ -1,0 +1,226 @@
+from pydicom import Dataset
+from pydicom.uid import UID, generate_uid
+from pynetdicom.sop_class import UnifiedProcedureStepPull, UnifiedProcedureStepPush
+from pynetdicom.status import UNIFIED_PROCEDURE_STEP_SERVICE_CLASS_STATUS
+
+from tdwii_plus_examples.basescu import BaseSCU
+
+# Action Type ID constants
+ACTION_TYPE_ID_CHANGEUPSSTATE = 1
+
+# UPS Procedure Step State constants
+SCHEDULED: str = "SCHEDULED"
+IN_PROGRESS: str = "IN PROGRESS"
+CANCELED: str = "CANCELED"
+COMPLETED: str = "COMPLETED"
+
+ALLOWED_STEP_STATES = (IN_PROGRESS, CANCELED, COMPLETED)
+
+
+class UPSPullNActionSCU(BaseSCU):
+    """
+    A subclass of BaseSCU that implements the N-ACTION DIMSE operation
+    for the Unified Procedure Step Pull SOP Class.
+
+    This class is derived from BaseSCU and implements the necessary methods
+    to request UPS Pull presentation contexts and perform N-ACTION requests
+    to change the state of a UPS instance.
+
+    Attributes:
+        logger: A logger instance.
+        calling_ae_title: The title of the calling AE.
+        called_ae_title: The title of the called AE.
+        called_ip: The IP address or hostname of the called AE.
+        called_port: The port number of the called AE.
+    """
+
+    def __init__(self, logger=None, calling_ae_title=None, called_ip=None, called_port=None, called_ae_title=None):
+        """
+        Initializes a UPSPullNActionSCU instance.
+
+        Parameters
+        ----------
+        logger : Logger, optional
+            The logger instance for logging messages.
+        calling_ae_title : str, optional
+            The AE title of the calling AE.
+        called_ip : str, optional
+            The IP address of the called AE.
+        called_port : int, optional
+            The port number of the called AE.
+        called_ae_title : str, optional
+            The AE title of the called AE.
+        """
+
+        super().__init__(
+            logger,
+            calling_ae_title=calling_ae_title,
+            called_ip=called_ip,
+            called_port=called_port,
+            called_ae_title=called_ae_title,
+        )
+        # Dictionary to store transaction UIDs for each UPS instance IN PROGRESS
+        self.ups_transaction_info = {}
+
+        self.logger.debug("UPSPullNActionSCU initialized")
+
+    def _add_requested_context(self):
+        """Adds the Unified Procedure Step Pull SOP Class presentation context."""
+        super()._add_requested_context()
+        self.ae.add_requested_context(UnifiedProcedureStepPull)
+        self.logger.debug(f"UPS Pull Presentation context added: {UnifiedProcedureStepPull}")
+
+    def _get_status_description(self, status_code):
+        """
+        Retrieves the description for a specific UPS status code.
+
+        Args:
+            status_code (int): The status code to look up.
+
+        Returns:
+            str: The description of the status code.
+        """
+        return UNIFIED_PROCEDURE_STEP_SERVICE_CLASS_STATUS.get(status_code, ("Unknown", "Unknown status code"))[1]
+
+    def claim_ups(self, sop_instance_uid):
+        """Claims a SCHEDULED UPS instance by generating a transaction UID, setting its state to IN PROGRESS,
+        and sending an N-ACTION request.
+
+        Args:
+            sop_instance_uid (str): The SOP Instance UID of the UPS to claim.
+
+        Returns:
+            pydicom.uid.UID | None: The transaction UID generated to lock the UPS, or None on failure.
+        """
+        action_info = Dataset()
+
+        # To take control of a SCHEDULED UPS, an SCU shall generate a Transaction UID
+        transaction_uid = generate_uid()
+
+        # and submit a state change to IN PROGRESS
+        action_info.ProcedureStepState = IN_PROGRESS
+
+        # including the Transaction UID in the submission.
+        action_info.TransactionUID = transaction_uid
+
+        result = self._change_ups_state(sop_instance_uid, action_info)
+
+        # The SCU shall record and use the Transaction UID in future N-ACTION and N-SET requests for that UPS instance.
+        if result.status_category == "Success":
+            self.ups_transaction_info[sop_instance_uid] = transaction_uid
+            return transaction_uid
+
+        return None
+
+    def complete_ups(self, sop_instance_uid, transaction_uid=None):
+        """Completes an IN PROGRESS UPS instance.
+
+        Upon completion of an IN PROGRESS UPS it controls, an SCU shall
+        submit a state change to COMPLETED.
+
+        Args:
+            sop_instance_uid (str): The SOP Instance UID of the UPS.
+            transaction_uid (str, optional): The Transaction UID of the UPS.
+                If not provided, the stored transaction UID will be used.
+
+        Returns:
+            bool: True if the UPS was successfully completed, False otherwise.
+        """
+        result = self._close_ups(sop_instance_uid, transaction_uid, COMPLETED)
+        return result.status_category == "Success"
+
+    def cancel_ups(self, sop_instance_uid, transaction_uid=None):
+        """Cancels an IN PROGRESS UPS instance.
+
+        To cancel an IN PROGRESS UPS, an SCU shall submit a state change to CANCELED.
+
+        Args:
+            sop_instance_uid (str): The SOP Instance UID of the UPS.
+            transaction_uid (str, optional): The Transaction UID of the UPS.
+                If not provided, the stored transaction UID will be used.
+
+        Returns:
+            bool: True if the UPS was successfully canceled, False otherwise.
+        """
+        result = self._close_ups(sop_instance_uid, transaction_uid, CANCELED)
+        return result.status_category == "Success"
+
+    def _close_ups(self, sop_instance_uid, transaction_uid, state):
+        """Sets the state of a UPS instance to COMPLETED or CANCELED.
+
+        Args:
+            sop_instance_uid (str): The SOP Instance UID of the UPS.
+            transaction_uid (UID, optional): The transaction UID.
+                If not provided, the stored one will be used.
+            state (str): The desired state of the UPS ("COMPLETED" or "CANCELED").
+
+        Returns:
+            PrimitiveResult: The result of the N-ACTION operation.
+        """
+        if not transaction_uid:
+            try:
+                transaction_uid = self.ups_transaction_info[sop_instance_uid]
+                self.logger.debug(f"Using stored transaction UID: {transaction_uid}")
+            except KeyError:
+                msg = "No Transaction UID found for the given SOP Instance UID"
+                self.logger.error(msg)
+                return self.PrimitiveResult("TransactionUIDFailure", 0xD001, msg, None)
+
+        action_info = Dataset()
+        action_info.ProcedureStepState = state
+        action_info.TransactionUID = transaction_uid
+
+        self.logger.debug(f"Setting UPS state to {state} with transaction UID {transaction_uid}")
+        result = self._change_ups_state(sop_instance_uid, action_info)
+
+        if result.status_category == "Success":
+            self.logger.info(f"Successfully set UPS state to {state}")
+            # Remove stored transaction_uid if present in the dict
+            self.ups_transaction_info.pop(sop_instance_uid, None)
+
+        return result
+
+    def _change_ups_state(self, sop_instance_uid, action_info):
+        """
+        Sends an N-ACTION request to change the state of a UPS instance.
+
+        Args:
+            sop_instance_uid (str): The SOP Instance UID of the UPS to act upon.
+            action_info (pydicom.Dataset): The Change UPS State Action Information
+                see PS3.4 Table CC.2.1-1.
+
+        Returns:
+            PrimitiveResult: A named tuple containing the status category, status code,
+            status description, and response dataset.
+        """
+        # Establish association with the SCP
+        assoc_result = self._associate(required_sop_classes=[UnifiedProcedureStepPull])
+
+        if assoc_result.status == "Error":
+            return self.PrimitiveResult("AssocFailure", 0xD000, assoc_result.description, None)
+
+        if assoc_result.status == "Warning":
+            accepted_sop_names = [f"[{UID(uid).name}]" for uid in assoc_result.accepted_sop_classes]
+            self.logger.warning(f"{assoc_result.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
+
+        # Send the N-ACTION request
+        self.logger.debug(f"Sending N-ACTION request for SOP Instance UID: {sop_instance_uid}")
+        rsp_status, action_reply = self.assoc.send_n_action(
+            dataset=action_info,
+            action_type=ACTION_TYPE_ID_CHANGEUPSSTATE,
+            class_uid=UnifiedProcedureStepPull,
+            instance_uid=sop_instance_uid,
+            meta_uid=UnifiedProcedureStepPush,
+        )
+
+        # Handle the response
+        result = self._handle_response(rsp_status, action_reply)
+
+        if result.status_category == "Success":
+            self.logger.info("N-ACTION request successful")
+        else:
+            self.logger.error(f"N-ACTION request failed: {result.status_description}")
+
+        self.assoc.release()
+
+        return result

--- a/tdwii_plus_examples/upspushncreatescu.py
+++ b/tdwii_plus_examples/upspushncreatescu.py
@@ -64,10 +64,10 @@ class UPSPushNCreateSCU(BaseSCU):
                 f"Some instances were ignored because their SOPClassUID did not match UnifiedProcedureStepPush. "
                 f"Total instances provided: {len(instances)}, valid instances: {len(valid_instances)}"
             )
-        assoc_result = self._associate()
+        assoc_result = self._associate(required_sop_classes=[UnifiedProcedureStepPush], verbose=False)
         success_count = 0
 
-        if not self._handle_association_status(assoc_result):
+        if not assoc_result:
             return 0
 
         for msg_id, instance in enumerate(valid_instances, start=0):
@@ -90,19 +90,6 @@ class UPSPushNCreateSCU(BaseSCU):
         self.logger.debug("Association released")
 
         return success_count
-
-    def _handle_association_status(self, assoc_result) -> bool:
-        if assoc_result.status == "Error":
-            self.logger.error(f"Association failed: {assoc_result.description}")
-            return False
-        if assoc_result.status == "Warning":
-            accepted_sop_names = [f"[{UID(uid).name}]" for uid in assoc_result.accepted_sop_classes]
-            self.logger.warning(f"{assoc_result.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
-            if "[Unified Procedure Step - Push SOP Class]" not in accepted_sop_names:
-                self.assoc.release()
-                self.logger.error(f"Association failed: {assoc_result.description}")
-                return False
-        return True
 
     def _send_upspushncreate_request(
         self,

--- a/tdwii_plus_examples/upspushncreatescu.py
+++ b/tdwii_plus_examples/upspushncreatescu.py
@@ -64,10 +64,10 @@ class UPSPushNCreateSCU(BaseSCU):
                 f"Some instances were ignored because their SOPClassUID did not match UnifiedProcedureStepPush. "
                 f"Total instances provided: {len(instances)}, valid instances: {len(valid_instances)}"
             )
-        assoc_result = self._associate(required_sop_classes=[UnifiedProcedureStepPush], verbose=False)
+        success, _ = self._associate(required_sop_classes=[UnifiedProcedureStepPush])
         success_count = 0
 
-        if not assoc_result:
+        if not success:
             return 0
 
         for msg_id, instance in enumerate(valid_instances, start=0):


### PR DESCRIPTION
This merge request addresses part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It refactors nactionscu.py from the tdwii_plus_examples folder.
The NActionSCU class is refactored as UPSPullNActionSCU in tdwii_plus_examples package folder in upspullnactionscu.py.
UPSPullNActionSCU is derived from a BaseSCU class.
The nactionscu CLI application in tdwii_plus_examples package folder is also refactored as upschangestatescu.py CLI application and moved to the tdwii_plus_examples/cli folder.
Tests are provided.
Finally, the GUI application in tdwii_plus_examples/tdd folder is refactored to use UPSPullNActionSCU class.

## Summary by Sourcery

Refactor the UPS (Unified Procedure Step) related classes and CLI application to improve modularity, separation of concerns, and enhance the implementation of the UPS Pull N-Action Service Class User (SCU).

New Features:
- Implement UPSPullNActionSCU class for managing UPS state changes
- Create upschangestatescu CLI application for UPS state management

Enhancements:
- Refactor BaseSCU to improve association and context handling
- Improve error handling and logging in DICOM service classes
- Add more robust transaction UID management for UPS operations

Tests:
- Add comprehensive unit and integration tests for UPSPullNActionSCU
- Enhance existing test coverage for BaseSCU and related classes

Chores:
- Reorganize project structure
- Improve code documentation