### PR TITLE
Refactor upsfindscu

### DIFF
--- a/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
+++ b/tdwii_plus_examples/TDWII_PPVS_subscriber/ppvs_subscriber_widget.py
@@ -29,10 +29,7 @@ from tdwii_plus_examples.TDWII_PPVS_subscriber.ppvsscp import PPVS_SCP
 from tdwii_plus_examples.TDWII_PPVS_subscriber.ui_tdwii_ppvs_subscriber import (
     Ui_MainPPVSSubscriberWidget,
 )
-from tdwii_plus_examples.TDWII_PPVS_subscriber.upsfindscu import (
-    create_ups_query,
-    get_ups,
-)
+from tdwii_plus_examples.upspullcfindscu import UPSPullCFindSCU
 from tdwii_plus_examples.upswatchnactionscu import UPSWatchNActionSCU
 
 
@@ -289,20 +286,26 @@ class PPVS_SubscriberWidget(QWidget):
         # do C-FIND-RQ
         my_ae_title = self.ui.ppvs_ae_line_edit.text()
         upsscp_ae_title = self.ui.ups_ae_line_edit.text()
+        upsscp_ip_addr = tdwii_config.known_ae_ipaddr[upsscp_ae_title]
+        upsscp_port = tdwii_config.known_ae_port[upsscp_ae_title]
         machine_name = self.ui.machine_name_line_edit.text()
         soonest_datetime_widget = self.ui.soonest_date_time_edit
         procedure_step_state = self.ui.step_status_combo_box.currentText()
         if procedure_step_state == "ANY":
             procedure_step_state = ""
 
-        query_ds = create_ups_query(
+        cfind_scu = UPSPullCFindSCU(
+            calling_ae_title=my_ae_title, called_ae_title=upsscp_ae_title, called_ip=upsscp_ip_addr, called_port=upsscp_port
+        )
+
+        query_ds = cfind_scu.create_ups_query(
             ups_uid=ups_uid,
             machine_name=machine_name,
             procedure_step_state=procedure_step_state,
             scheduled_no_sooner_than=soonest_datetime_widget.dateTime().toString("yyyyMMddhhmm"),
             scheduled_no_later_than=self.ui.latest_date_time_edit.dateTime().toString("yyyyMMddhhmm"),
         )
-        responses = get_ups(query_ds, my_ae_title, upsscp_ae_title)
+        responses = cfind_scu.get_ups(query_ds)
 
         self.ui.ups_response_tree_widget.clear()
         self.ups_dataset_dict.clear()

--- a/tdwii_plus_examples/_dicom_macros.py
+++ b/tdwii_plus_examples/_dicom_macros.py
@@ -1,6 +1,34 @@
+from enum import Enum, unique
+
 from pydicom import Sequence
 from pydicom.dataset import Dataset
 from pydicom.uid import UID
+
+
+@unique
+class ValueType(Enum):
+    """
+    Enumerates the allowed Content Item Value Type as defined in PS3.3 C.17.3.2.1
+
+    """
+
+    TEXT = "TEXT"
+    NUM = "NUM"
+    NUMERIC = "NUMERIC"  # not in Table C.17.3-7 !?
+    CODE = "CODE"
+    DATETIME = "DATETIME"
+    DATE = "DATE"
+    TIME = "TIME"
+    UIDREF = "UIDREF"
+    PNAME = "PNAME"
+    COMPOSITE = "COMPOSITE"
+    IMAGE = "IMAGE"
+    WAVEFORM = "WAVEFORM"
+    SCOORD = "SCOORD"
+    SCOORD3D = "SCOORD3D"
+    TCOORD = "TCOORD"
+    CONTAINER = "CONTAINER"
+    TABLE = "TABLE"
 
 
 def create_measurement_unit_code_seq_item(value_unit: str = None) -> Dataset:
@@ -43,14 +71,14 @@ def create_code_seq_item(value: str | int, designator: str, meaning: str) -> Dat
     return code_seq_item
 
 
-def create_content_item(value_type: str, value: any, code_seq_item: Dataset, value_unit: str = None) -> Dataset:
+def create_content_item(value_type: ValueType, value: any, code_seq_item: Dataset, value_unit: str = None) -> Dataset:
     """
-    Create a DICOM Content Item Dataset for use in structured reports or UPS.
+    Create a DICOM Content Item Dataset for use in Code Sequences of UPS.
     See PS3.3 Table 10-2. Content Item Macro Attributes
     See PS3.16 7.2.2 Measurement Unit
 
     Args:
-        value_type (str): The type of value ("TEXT" or "NUMERIC").
+        value_type (ValueType): The VT (ValueType.TEXT or ValueType.NUMERIC).
         value_unit (str): The unit of a value of type NUMERIC. Defaults to None.
         value (any): The value to store.
         code_seq_item (Dataset): The concept name code sequence item.
@@ -59,12 +87,12 @@ def create_content_item(value_type: str, value: any, code_seq_item: Dataset, val
         Dataset: DICOM content item.
     """
     content_item = Dataset()
-    content_item.ValueType = value_type
+    content_item.ValueType = value_type.value
     if code_seq_item is not None:
         content_item.ConceptNameCodeSequence = Sequence([code_seq_item])
-    if value_type == "TEXT":
+    if value_type == ValueType.TEXT:
         content_item.TextValue = str(value)
-    elif value_type == "NUMERIC":
+    elif value_type == ValueType.NUMERIC:
         content_item.MeasurementUnitsCodeSequence = Sequence([create_measurement_unit_code_seq_item()])
         content_item.NumericValue = value
     else:

--- a/tdwii_plus_examples/cli/upsfind.py
+++ b/tdwii_plus_examples/cli/upsfind.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+import argparse
+import logging
+import os
+
+from pydicom.dataset import FileMetaDataset
+from pydicom.uid import PYDICOM_IMPLEMENTATION_UID, ExplicitVRLittleEndian
+
+from tdwii_plus_examples.upspullcfindscu import UPSPullCFindSCU
+
+
+def main():
+    parser = argparse.ArgumentParser(description="UPS C-FIND SCU (UPS Query)")
+    parser.add_argument("ip", type=str, help="IP address or hostname of called AE")
+    parser.add_argument("port", type=int, help="TCP port number of called AE")
+    parser.add_argument("-aet", "--ae_title", type=str, default="UPSFINDSCU", help="Application Entity Title")
+    parser.add_argument("-aec", "--called_ae_title", type=str, default="ANYSCP", help="Called Application Entity Title")
+    parser.add_argument("--ups_uid", type=str, default="", help="SOP Instance UID for the specific UPS (optional)")
+    parser.add_argument("--machine", type=str, default="", help="Treatment machine name (optional)")
+    parser.add_argument("--state", type=str, default="SCHEDULED", help="Procedure Step State (default: SCHEDULED)")
+    parser.add_argument("--start", type=str, default=None, help="UPS start Date and Time (optional)")
+    parser.add_argument("--end", type=str, default=None, help="UPS End Date and Time (optional)")
+    parser.add_argument(
+        "--save",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help="Directory to save matching UPS responses as a DICOM Part 10 file",
+    )
+    parser.add_argument("--raw", action="store_true", help="Save as raw DICOM dataset (no File Meta Information)")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Set log level to INFO")
+    parser.add_argument("-d", "--debug", action="store_true", help="Set log level to DEBUG")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all log output")
+
+    args = parser.parse_args()
+
+    if args.quiet:
+        log_level = logging.CRITICAL
+    elif args.verbose:
+        log_level = logging.INFO
+    elif args.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.WARNING
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger("upsfind")
+    logger.setLevel(log_level)
+
+    logger.info(f"Initializing UPSPullCFindSCU instance with remote SCP {args.called_ae_title}@{args.ip}:{args.port}")
+    scu = UPSPullCFindSCU(
+        logger=logger,
+        calling_ae_title=args.ae_title,
+        called_ip=args.ip,
+        called_port=args.port,
+        called_ae_title=args.called_ae_title,
+    )
+
+    # Build the UPS query dataset using the provided options
+    ds_query = scu.create_ups_query(
+        ups_uid=args.ups_uid,
+        machine_name=args.machine,
+        procedure_step_state=args.state,
+        scheduled_no_sooner_than=args.start,
+        scheduled_no_later_than=args.end,
+    )
+
+    # Perform the C-FIND operation
+    ups_responses = scu.get_ups(ds_query)
+
+    if not ups_responses:
+        print("No UPS instances found matching the query.")
+    else:
+        print(f"Found {len(ups_responses)} UPS instance(s):")
+        for i, ds in enumerate(ups_responses, 1):
+            print(f"\n--- UPS Instance {i} ---")
+            print(ds)
+            if args.save:
+                os.makedirs(args.save, exist_ok=True)
+                # Use SOPInstanceUID as filename if present, else index
+                if hasattr(ds, "SOPInstanceUID") and ds.SOPInstanceUID:
+                    filename = f"UPS_{ds.SOPInstanceUID}.dcm"
+                else:
+                    filename = f"UPS_{i}.dcm"
+                file_path = os.path.join(args.save, filename)
+                # Set transfer syntax attributes before saving
+                ds.is_little_endian = True
+                ds.is_implicit_VR = False
+                if not args.raw:
+                    # Add file meta information for Part 10
+                    file_meta = FileMetaDataset()
+                    file_meta.MediaStorageSOPClassUID = ds.SOPClassUID
+                    file_meta.MediaStorageSOPInstanceUID = ds.SOPInstanceUID
+                    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+                    file_meta.ImplementationClassUID = PYDICOM_IMPLEMENTATION_UID
+                    ds.file_meta = file_meta
+                try:
+                    ds.save_as(file_path, write_like_original=args.raw)
+                    print(f"Saved UPS Identifier {i} to {file_path}")
+                except Exception as e:
+                    print(f"Failed to save UPS Identifier {i} to {file_path}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tdwii_plus_examples/tdd/tdd_widget.py
+++ b/tdwii_plus_examples/tdd/tdd_widget.py
@@ -33,10 +33,7 @@ from tdwii_plus_examples.nsetscu import NSetSCU
 #     pyside2-uic form.ui -o ui_form.py
 from tdwii_plus_examples.tdd.ui_tdd import Ui_MainTDDWidget
 from tdwii_plus_examples.TDWII_PPVS_subscriber.ppvsscp import PPVS_SCP
-from tdwii_plus_examples.TDWII_PPVS_subscriber.upsfindscu import (
-    create_ups_query,
-    get_ups,
-)
+from tdwii_plus_examples.upspullcfindscu import UPSPullCFindSCU
 from tdwii_plus_examples.upspullnactionscu import UPSPullNActionSCU
 from tdwii_plus_examples.upswatchnactionscu import UPSWatchNActionSCU
 
@@ -373,20 +370,26 @@ class TDD_Widget(QWidget):
         # do C-FIND-RQ
         my_ae_title = self.ui.tdd_ae_line_edit.text()
         upsscp_ae_title = self.ui.ups_ae_line_edit.text()
+        upsscp_ip_addr = tdwii_config.known_ae_ipaddr[upsscp_ae_title]
+        upsscp_port = tdwii_config.known_ae_port[upsscp_ae_title]
         machine_name = self.ui.machine_name_line_edit.text()
         soonest_datetime_widget = self.ui.soonest_date_time_edit
         procedure_step_state = self.ui.step_status_combo_box.currentText()
         if procedure_step_state == "ANY":
             procedure_step_state = ""
 
-        query_ds = create_ups_query(
+        cfind_scu = UPSPullCFindSCU(
+            calling_ae_title=my_ae_title, called_ae_title=upsscp_ae_title, called_ip=upsscp_ip_addr, called_port=upsscp_port
+        )
+
+        query_ds = cfind_scu.create_ups_query(
             ups_uid=ups_uid,
             machine_name=machine_name,
             procedure_step_state=procedure_step_state,
             scheduled_no_sooner_than=soonest_datetime_widget.dateTime().toString("yyyyMMddhhmm"),
             scheduled_no_later_than=self.ui.latest_date_time_edit.dateTime().toString("yyyyMMddhhmm"),
         )
-        responses = get_ups(query_ds, my_ae_title, upsscp_ae_title)
+        responses = cfind_scu.get_ups(query_ds)
 
         self.ui.ups_response_tree_widget.clear()
         self.ups_dataset_dict.clear()

--- a/tdwii_plus_examples/tests/cli/test_upsfind.py
+++ b/tdwii_plus_examples/tests/cli/test_upsfind.py
@@ -1,0 +1,132 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pydicom import Dataset
+from pydicom.uid import generate_uid
+from pynetdicom.sop_class import UnifiedProcedureStepPush
+
+from tdwii_plus_examples.cli.upsfind import main as upsfind_main
+
+
+class TestUpsFindSCU(unittest.TestCase):
+    def test_no_ups_found(self):
+        with (
+            patch.object(sys, "argv", ["upsfind.py", "localhost", "11114"]),
+            patch("tdwii_plus_examples.cli.upsfind.UPSPullCFindSCU") as mock_scu_class,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_scu = MagicMock()
+            mock_scu_class.return_value = mock_scu
+            mock_query = Dataset()
+            mock_scu.create_ups_query.return_value = mock_query
+            mock_scu.get_ups.return_value = []
+
+            upsfind_main()
+
+            mock_scu.create_ups_query.assert_called_once()
+            mock_scu.get_ups.assert_called_once_with(mock_query)
+            found = any("No UPS instances found matching the query." in str(call) for call in mock_print.call_args_list)
+            self.assertTrue(found, "Expected print for no UPS found")
+
+    def test_ups_found_and_save_part10(self):
+        # This test covers both the default save (Part 10) and the "happy path" for multiple results.
+        with (
+            patch.object(sys, "argv", ["upsfind.py", "localhost", "11114", "--save", "testdir"]),
+            patch("tdwii_plus_examples.cli.upsfind.UPSPullCFindSCU") as mock_scu_class,
+            patch("builtins.print") as mock_print,
+            patch("os.makedirs") as mock_makedirs,
+        ):
+            mock_scu = MagicMock()
+            mock_scu_class.return_value = mock_scu
+            mock_query = Dataset()
+            mock_scu.create_ups_query.return_value = mock_query
+            ds1 = Dataset()
+            ds1.SOPInstanceUID = generate_uid()
+            ds1.SOPClassUID = UnifiedProcedureStepPush
+            ds1.save_as = MagicMock()
+            ds2 = Dataset()
+            ds2.SOPInstanceUID = generate_uid()
+            ds2.SOPClassUID = UnifiedProcedureStepPush
+            ds2.save_as = MagicMock()
+            mock_scu.get_ups.return_value = [ds1, ds2]
+
+            upsfind_main()
+
+            mock_scu.create_ups_query.assert_called_once()
+            mock_scu.get_ups.assert_called_once_with(mock_query)
+            found = any("Found 2 UPS instance(s):" in str(call) for call in mock_print.call_args_list)
+            self.assertTrue(found, "Expected print for found UPS instances")
+            mock_makedirs.assert_called_with("testdir", exist_ok=True)
+            ds1.save_as.assert_called_with(unittest.mock.ANY, write_like_original=False)
+            ds2.save_as.assert_called_with(unittest.mock.ANY, write_like_original=False)
+
+    def test_ups_found_missing_sopinstanceuid(self):
+        # Test a dataset without SOPInstanceUID (should use index in filename)
+        with (
+            patch.object(sys, "argv", ["upsfind.py", "localhost", "11114", "--save", "testdir"]),
+            patch("tdwii_plus_examples.cli.upsfind.UPSPullCFindSCU") as mock_scu_class,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_scu = MagicMock()
+            mock_scu_class.return_value = mock_scu
+            mock_query = Dataset()
+            mock_scu.create_ups_query.return_value = mock_query
+            ds = Dataset()
+            ds.SOPClassUID = UnifiedProcedureStepPush
+            ds.SOPInstanceUID = ""
+            ds.save_as = MagicMock()
+            mock_scu.get_ups.return_value = [ds]
+
+            upsfind_main()
+
+            # Check that the fallback filename (using index) is used in print output
+            found = any("UPS_1.dcm" in str(call) for call in mock_print.call_args_list)
+            self.assertTrue(found, "Expected fallback filename 'UPS_1.dcm' in output")
+
+    def test_custom_query_args(self):
+        # Test that custom query args are passed to create_ups_query
+        uid = generate_uid()
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "upsfind.py",
+                    "localhost",
+                    "11114",
+                    "--ups_uid",
+                    uid,
+                    "--machine",
+                    "GTR1",
+                    "--state",
+                    "IN PROGRESS",
+                    "--start",
+                    "202501010000",
+                    "--end",
+                    "202501011200",
+                ],
+            ),
+            patch("tdwii_plus_examples.cli.upsfind.UPSPullCFindSCU") as mock_scu_class,
+            patch("builtins.print"),
+            patch("os.makedirs"),
+        ):
+            mock_scu = MagicMock()
+            mock_scu_class.return_value = mock_scu
+            mock_query = Dataset()
+            mock_scu.create_ups_query.return_value = mock_query
+            mock_scu.get_ups.return_value = []
+
+            upsfind_main()
+
+            mock_scu.create_ups_query.assert_called_once_with(
+                ups_uid=uid,
+                machine_name="GTR1",
+                procedure_step_state="IN PROGRESS",
+                scheduled_no_sooner_than="202501010000",
+                scheduled_no_later_than="202501011200",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/cli/test_upsmodifyscu.py
+++ b/tdwii_plus_examples/tests/cli/test_upsmodifyscu.py
@@ -10,7 +10,7 @@ class TestUpsModifySCU(unittest.TestCase):
         # Patch sys.argv for argparse
         with (
             patch.object(sys, "argv", test_args),
-            patch("tdwii_plus_examples.cli.upsmodifyscu._create_sample_ups", return_value="1.2.3.4.5"),
+            patch("tdwii_plus_examples.cli.upsmodifyscu._ncreate_sample_ups", return_value="1.2.3.4.5"),
             patch("tdwii_plus_examples.cli.upsmodifyscu._claim_ups", return_value="1.2.3.4.5.6"),
             patch("tdwii_plus_examples.cli.upsmodifyscu.UPSPullNSetSCU") as mock_scu_class,
             patch("tdwii_plus_examples.cli.upsmodifyscu.dcmread", return_value="mock_ds"),
@@ -118,7 +118,7 @@ class TestUpsModifySCU(unittest.TestCase):
 
         print("Test: Happy path - create and claim")
         with (
-            patch("tdwii_plus_examples.cli.upsmodifyscu._create_sample_ups", return_value="created_uid"),
+            patch("tdwii_plus_examples.cli.upsmodifyscu._ncreate_sample_ups", return_value="created_uid"),
             patch("tdwii_plus_examples.cli.upsmodifyscu._claim_ups", return_value="claimed_tx_uid"),
         ):
 

--- a/tdwii_plus_examples/tests/test_upspullcfindscu_integration.py
+++ b/tdwii_plus_examples/tests/test_upspullcfindscu_integration.py
@@ -1,0 +1,174 @@
+import logging
+import os
+import shutil
+import signal
+import tempfile
+import unittest
+from logging import StreamHandler
+from subprocess import TimeoutExpired
+
+import psutil
+
+from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_ups
+from tdwii_plus_examples.tests.utils.utils import get_configured_logger, start_scp
+from tdwii_plus_examples.upspullcfindscu import UPSPullCFindSCU
+from tdwii_plus_examples.upspushncreatescu import UPSPushNCreateSCU
+
+
+class TestUPSPullCFindSCUIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Set up the logger for the SCU to DEBUG level with a stream handler
+        cls.scu_logger, cls.stream_handler = get_configured_logger(
+            "upspullnsetscu", level=logging.INFO, handler_class=StreamHandler
+        )
+
+        # Set up the logger for this test to DEBUG level
+        cls.test_logger, cls.stream_handler = get_configured_logger("test_upspullcfindscu", level=logging.DEBUG)
+
+        # Create a temporary directory for UPSSCP staging area
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.test_logger.info(f"{cls.temp_dir} directory created")
+
+        # Start the UPS SCP Server (replace with your actual SCP command)
+        command = [
+            "./tdwii_plus_examples/cli/upsscp/upsscp.py",
+            "-d",
+            "--database-location",
+            f"{cls.temp_dir}/test.sqlite",
+            "--instance-location",
+            cls.temp_dir,
+        ]
+
+        cls.upsscp_started, cls.process, cls.stdout_thread, cls.stdout_lines = start_scp(command, cls.test_logger)
+        cls.test_logger.info(f"Started process with PID: {cls.process.pid}")
+
+        if not cls.upsscp_started:
+            raise RuntimeError("upsscp server failed to start.")
+
+        # Create the UPSPullCFindSCU instance
+        cls.scu = UPSPullCFindSCU(
+            calling_ae_title="UPSPULLSCU",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=cls.scu_logger,
+        )
+
+        # Create 2 UPS in the SCP
+        ups_instances = []
+        ups_instances.extend(generate_ups() for _ in range(2))
+        push_scu = UPSPushNCreateSCU(
+            calling_ae_title="UPSPUSHSCU",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=cls.scu_logger,
+        )
+        num_created_instances = push_scu.create_ups_instances(ups_instances)
+
+        if num_created_instances != 2:
+            cls.tearDownClass()
+            cls.fail("Failed to create UPS instances.")
+
+        # Store the SOPInstanceUIDs and machine names of all created instances in lists
+        cls.sop_instance_uids = [ds.SOPInstanceUID for ds in ups_instances]
+        cls.machine_names = [ds.ScheduledStationNameCodeSequence[0].CodeValue for ds in ups_instances]
+
+    @classmethod
+    def tearDownClass(cls):
+        # Try to gracefully terminate the process.
+        cls.test_logger.info(f"Terminating process with PID: {cls.process.pid}")
+        try:
+            cls.process.terminate()
+            cls.process.wait(timeout=1)
+            cls.test_logger.info("Process terminated gracefully.")
+        except (ChildProcessError, TimeoutExpired):
+            cls.test_logger.warning("Process termination timed out or process already finished.")
+
+        # Try to kill child processes.
+        try:
+            parent = psutil.Process(cls.process.pid)
+            for child in parent.children(recursive=True):
+                child.kill()
+            cls.test_logger.info("Child processes terminated.")
+        except psutil.NoSuchProcess:
+            cls.test_logger.warning("Error killing subprocesses. Parent process not found. Probably already terminated.")
+
+        # Try to forcefully kill the process.
+        try:
+            os.kill(cls.process.pid, signal.SIGKILL)
+            cls.process.wait(timeout=1)  # Ensure process termination
+            cls.test_logger.info("Process forcefully terminated.")
+        except OSError:
+            cls.test_logger.warning("Error killing process. Probably already terminated.")
+
+        finally:
+            # Ensure the stdout thread has finished
+            if cls.stdout_thread:
+                cls.stdout_thread.join(timeout=1.0)
+
+        # Print the SCP server output
+        if hasattr(cls, "stdout_lines"):
+            print(
+                "\n"
+                + "*" * 80
+                + "\n*** BEGIN SCP SERVER OUTPUT ***\n"
+                + "\n".join(cls.stdout_lines)
+                + "\n*** END SCP SERVER OUTPUT ***\n"
+                + "*" * 80
+                + "\n"
+            )
+
+        # Remove the temporary directory and its contents
+        files_in_temp_dir = os.listdir(cls.temp_dir)
+        shutil.rmtree(cls.temp_dir)
+        cls.test_logger.info(f"Removed the temp directory: {cls.temp_dir} and its contents: {files_in_temp_dir}")
+
+        # Remove and close the handlers for scu and test loggers
+        for logger, handler in [(cls.scu_logger, cls.stream_handler), (cls.test_logger, cls.stream_handler)]:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_find_ups_by_uid(self):
+        """Integration test: find a UPS by SOPInstanceUID."""
+        scu = UPSPullCFindSCU(
+            calling_ae_title="UPSPUSHSCU",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=self.scu_logger,
+        )
+        ds_query = scu.create_ups_query(
+            ups_uid=self.sop_instance_uids[0],
+            machine_name="",
+            procedure_step_state="",
+        )
+        ups_responses = scu.get_ups(ds_query)
+        self.assertTrue(any(ds.SOPInstanceUID == self.sop_instance_uids[0] for ds in ups_responses))
+
+    def test_find_ups_by_machine(self):
+        """Integration test: find UPS by machine name and check all created instances are found."""
+        scu = UPSPullCFindSCU(
+            calling_ae_title="UPSPUSHSCU",
+            called_ae_title="UPSSCP",
+            called_ip="localhost",
+            called_port=11114,
+            logger=self.scu_logger,
+        )
+        ds_query = scu.create_ups_query(
+            ups_uid="",
+            machine_name=self.machine_names[0],
+            procedure_step_state="SCHEDULED",
+        )
+        ups_responses = scu.get_ups(ds_query)
+        # Assert that there are 2 UPS in the response
+        self.assertEqual(len(ups_responses), 2)
+        # Assert that their SOPInstanceUIDs match the ones we created (order-independent)
+        response_uids = sorted(ds.SOPInstanceUID for ds in ups_responses)
+        created_uids = sorted(self.sop_instance_uids)
+        self.assertEqual(response_uids, created_uids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/test_upspullcfindscu_unit.py
+++ b/tdwii_plus_examples/tests/test_upspullcfindscu_unit.py
@@ -1,0 +1,212 @@
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+from pydicom import Dataset
+from pydicom.uid import generate_uid
+from pynetdicom.sop_class import UnifiedProcedureStepPull
+
+from tdwii_plus_examples.upspullcfindscu import UPSPullCFindSCU
+
+
+class TestUPSPullCFindSCU(unittest.TestCase):
+    def setUp(self):
+        """Setup before each test."""
+        self.scu = UPSPullCFindSCU(
+            logger=None,
+            calling_ae_title="CALLING_AE",
+            called_ip="127.0.0.1",
+            called_port=11112,
+            called_ae_title="CALLED_AE",
+        )
+
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._associate")
+    def test_get_ups_success(self, mock_associate, mock_handle_response):
+        """Test successful C-FIND query for UPS instances."""
+        # Mock association result
+        mock_assoc_result = mock.Mock()
+        mock_assoc_result.status = "Success"
+        mock_associate.return_value = True, mock_assoc_result
+
+        # Mock association object and send_c_find
+        mock_assoc_obj = mock.Mock()
+        # Simulate two C-FIND responses with status "Pending"
+        ds1 = Dataset()
+        ds2 = Dataset()
+        mock_assoc_obj.send_c_find.return_value = [
+            (mock.Mock(Status=0xFF00), ds1),
+            (mock.Mock(Status=0xFF00), ds2),
+            (mock.Mock(Status=0x0000), None),  # Success
+        ]
+        mock_assoc_obj.release = mock.Mock()
+        self.scu.assoc = mock_assoc_obj
+
+        # Mock handle_response to return a "Pending" result for first two, "Success" for last
+        pending_result = mock.Mock(status_category="Pending")
+        success_result = mock.Mock(status_category="Success")
+        mock_handle_response.side_effect = [pending_result, pending_result, success_result]
+
+        ds_query = Dataset()
+        result = self.scu.get_ups(ds_query)
+
+        mock_associate.assert_called_once_with(required_sop_classes=[UnifiedProcedureStepPull])
+        mock_assoc_obj.send_c_find.assert_called_once_with(ds_query, query_model=UnifiedProcedureStepPull)
+        self.assertEqual(mock_handle_response.call_count, 3)
+        mock_assoc_obj.release.assert_called_once()
+        self.assertEqual(result, [ds1, ds2])
+
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._associate")
+    def test_get_ups_assoc_error(self, mock_associate, mock_handle_response):
+        """Test C-FIND query fails if association fails."""
+        mock_assoc_result = mock.Mock()
+        mock_assoc_result.status = "Error"
+        mock_assoc_result.description = "Association failed"
+        mock_associate.return_value = False, mock_assoc_result
+
+        # Mock assoc to test that the release method is not called
+        mock_assoc_obj = mock.Mock()
+        mock_assoc_obj.release = mock.Mock()
+        self.scu.assoc = mock_assoc_obj
+
+        ds_query = Dataset()
+        result = self.scu.get_ups(ds_query)
+
+        mock_associate.assert_called_once_with(required_sop_classes=[UnifiedProcedureStepPull])
+        mock_handle_response.assert_not_called()
+        self.scu.assoc.release.assert_not_called()
+        self.assertEqual(result, [])
+
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._associate")
+    def test_get_ups_warning(self, mock_associate, mock_handle_response):
+        """Test C-FIND query with association warning."""
+        mock_assoc_result = mock.Mock()
+        mock_assoc_result.status = "Warning"
+        mock_assoc_result.description = "Association warning"
+        mock_assoc_result.accepted_sop_classes = ["1.2.840.10008.5.1.4.34.5"]
+        mock_associate.return_value = True, mock_assoc_result
+
+        # Mock association object and send_c_find
+        mock_assoc_obj = mock.Mock()
+        ds1 = Dataset()
+        mock_assoc_obj.send_c_find.return_value = [
+            (mock.Mock(Status=0xFF00), ds1),
+            (mock.Mock(Status=0x0000), None),
+        ]
+        mock_assoc_obj.release = mock.Mock()
+        self.scu.assoc = mock_assoc_obj
+
+        pending_result = mock.Mock(status_category="Pending")
+        success_result = mock.Mock(status_category="Success")
+        mock_handle_response.side_effect = [pending_result, success_result]
+
+        ds_query = Dataset()
+        result = self.scu.get_ups(ds_query)
+
+        mock_associate.assert_called_once_with(required_sop_classes=[UnifiedProcedureStepPull])
+        mock_assoc_obj.send_c_find.assert_called_once_with(ds_query, query_model=UnifiedProcedureStepPull)
+        self.assertEqual(mock_handle_response.call_count, 2)
+        mock_assoc_obj.release.assert_called_once()
+        self.assertEqual(result, [ds1])
+
+    @parameterized.expand(
+        [
+            # (description, send_c_find_return, handle_response_side_effect, expected_result, expected_call_count)
+            (
+                "failure_status",
+                [
+                    (mock.Mock(Status=0xFF00), Dataset()),  # Pending
+                    (mock.Mock(Status=0xC322), None),  # Failure
+                ],
+                [
+                    mock.Mock(status_category="Pending"),
+                    mock.Mock(status_category="Failure", status_description="Unable to process"),
+                ],
+                [Dataset()],  # Only the first dataset should be returned
+                2,
+            ),
+            (
+                "pending_no_dataset",
+                [
+                    (mock.Mock(Status=0xFF00), None),  # Pending with no dataset
+                    (mock.Mock(Status=0x0000), None),  # Success
+                ],
+                [mock.Mock(status_category="Pending"), mock.Mock(status_category="Success")],
+                [],  # No datasets should be returned
+                1,  # Breaking on error is expected
+            ),
+            ("empty_response_list", [], [], [], 0),
+        ]
+    )
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._handle_response")
+    @mock.patch("tdwii_plus_examples.upspullcfindscu.UPSPullCFindSCU._associate")
+    def test_get_ups_failures(
+        self,
+        name,
+        send_c_find_return,
+        handle_response_side_effect,
+        expected_result,
+        expected_call_count,
+        mock_associate,
+        mock_handle_response,
+    ):
+        """Test C-FIND query failure and edge cases using parameterized."""
+        mock_assoc_result = mock.Mock()
+        mock_assoc_result.status = "Success"
+        mock_associate.return_value = True, mock_assoc_result
+
+        # Mock association object and send_c_find
+        mock_assoc_obj = mock.Mock()
+        # If there are Dataset() objects in send_c_find_return, replace with unique objects for assertion
+        for idx, (status, ds) in enumerate(send_c_find_return):
+            if isinstance(ds, Dataset):
+                send_c_find_return[idx] = (status, Dataset())
+        mock_assoc_obj.send_c_find.return_value = send_c_find_return
+        mock_assoc_obj.release = mock.Mock()
+        self.scu.assoc = mock_assoc_obj
+
+        mock_handle_response.side_effect = handle_response_side_effect
+
+        ds_query = Dataset()
+        result = self.scu.get_ups(ds_query)
+
+        mock_associate.assert_called_once_with(required_sop_classes=[UnifiedProcedureStepPull])
+        mock_assoc_obj.send_c_find.assert_called_once_with(ds_query, query_model=UnifiedProcedureStepPull)
+        self.assertEqual(mock_handle_response.call_count, expected_call_count)
+        mock_assoc_obj.release.assert_called_once()
+        # Compare the number of datasets returned, since Dataset() objects are not the same
+        self.assertEqual(len(result), len(expected_result))
+
+    def test_create_ups_query(self):
+        """Test the creation of a UPS query dataset with various parameters."""
+        # Test with all defaults
+        ds = self.scu.create_ups_query()
+        self.assertIn("SOPInstanceUID", ds)
+        self.assertIn("PatientName", ds)
+        self.assertIn("PatientID", ds)
+        self.assertIn("ScheduledWorkitemCodeSequence", ds)
+        self.assertIn("InputInformationSequence", ds)
+        self.assertIn("ScheduledStationNameCodeSequence", ds)
+        self.assertIn("ProcedureStepState", ds)
+        self.assertIn("ScheduledProcessingParametersSequence", ds)
+        self.assertIn("WorklistLabel", ds)
+        self.assertIn("ScheduledProcedureStepStartDateTime", ds)
+        # Test with specific values
+        sop_instance_uid = generate_uid()
+        ds2 = self.scu.create_ups_query(
+            ups_uid=sop_instance_uid,
+            machine_name="Gantry1",
+            procedure_step_state="IN PROGRESS",
+            scheduled_no_sooner_than="202501010000",
+            scheduled_no_later_than="202501012359",
+        )
+        self.assertEqual(ds2.SOPInstanceUID, sop_instance_uid)
+        self.assertEqual(ds2.ScheduledStationNameCodeSequence[0].CodeValue, "Gantry1")
+        self.assertEqual(ds2.ProcedureStepState, "")
+        self.assertEqual(ds2.ScheduledProcedureStepStartDateTime, "202501010000-202501012359")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tdwii_plus_examples/tests/utils/generate_sample_ups.py
+++ b/tdwii_plus_examples/tests/utils/generate_sample_ups.py
@@ -5,7 +5,7 @@ from tdwii_plus_examples.tests.utils.generate_sop_instances import generate_ups_
 
 def main():
     if len(sys.argv) not in (2, 3):
-        print("Usage: python create_sample_ups.py <folder_path> [file_name]")
+        print("Usage: python generate_sample_ups.py <folder_path> [file_name]")
         sys.exit(1)
     folder_path = sys.argv[1]
     file_name = sys.argv[2] if len(sys.argv) == 3 else None

--- a/tdwii_plus_examples/tests/utils/generate_sop_instances.py
+++ b/tdwii_plus_examples/tests/utils/generate_sop_instances.py
@@ -9,6 +9,7 @@ from pydicom.uid import PYDICOM_IMPLEMENTATION_UID, UID, ExplicitVRLittleEndian,
 from pynetdicom.sop_class import RTBeamsDeliveryInstructionStorage, RTIonPlanStorage
 
 from tdwii_plus_examples._dicom_macros import (
+    ValueType,
     create_code_seq_item,
     create_content_item,
     create_referenced_instances_and_access_item,
@@ -330,22 +331,24 @@ def generate_ups() -> Dataset:
 
     treatment_delivery_concept = create_code_seq_item("121740", "DCM", "Treatment Delivery Type")
     treatment_delivery_type = "TREATMENT"
-    treatment_param_item = create_content_item("TEXT", treatment_delivery_type, treatment_delivery_concept)
+    treatment_param_item = create_content_item(ValueType.TEXT, treatment_delivery_type, treatment_delivery_concept)
     scheduled_processing_parameters_list.append(treatment_param_item)
 
     plan_label_concept = create_code_seq_item("2018001", "99IHERO2018", "Plan Label")
     plan_label_value = "No Plan Label"
-    plan_label_item = create_content_item("TEXT", plan_label_value, plan_label_concept)
+    plan_label_item = create_content_item(ValueType.TEXT, plan_label_value, plan_label_concept)
     scheduled_processing_parameters_list.append(plan_label_item)
 
     current_fraction_concept = create_code_seq_item("2018002", "99IHERO2018", "Current Fraction Number")
     current_fraction_number = "1"
-    current_fraction_item = create_content_item("NUMERIC", int(current_fraction_number), current_fraction_concept)
+    current_fraction_item = create_content_item(ValueType.NUMERIC, int(current_fraction_number), current_fraction_concept)
     scheduled_processing_parameters_list.append(current_fraction_item)
 
     fractions_planned_concept = create_code_seq_item("2018003", "99IHERO2018", "Number of Fractions Planned")
     number_of_fractions_planned = "30"
-    fractions_planned_item = create_content_item("NUMERIC", int(number_of_fractions_planned), fractions_planned_concept)
+    fractions_planned_item = create_content_item(
+        ValueType.NUMERIC, int(number_of_fractions_planned), fractions_planned_concept
+    )
     scheduled_processing_parameters_list.append(fractions_planned_item)
 
     ds.ScheduledProcessingParametersSequence = Sequence(scheduled_processing_parameters_list)  # Type 2. RC+*

--- a/tdwii_plus_examples/upspullcfindscu.py
+++ b/tdwii_plus_examples/upspullcfindscu.py
@@ -1,0 +1,208 @@
+from pydicom import DataElement, Dataset, Sequence
+from pydicom.uid import UID
+from pydicom.valuerep import VR
+from pynetdicom.sop_class import UnifiedProcedureStepPull
+
+from tdwii_plus_examples._dicom_macros import create_code_seq_item
+from tdwii_plus_examples.basescu import BaseSCU
+
+
+class UPSPullCFindSCU(BaseSCU):
+    """
+    A subclass of BaseSCU that implements the C-FIND DIMSE operation
+    for the Unified Procedure Step Pull SOP Class.
+
+    This class is derived from BaseSCU and implements the necessary methods
+    to request UPS Pull presentation contexts and perform C-FIND requests
+    to query UPS instances.
+    """
+
+    def __init__(self, logger=None, calling_ae_title=None, called_ip=None, called_port=None, called_ae_title=None):
+        """
+        Initializes a UPSPullCFindSCU instance.
+
+        Parameters
+        ----------
+        logger : Logger, optional
+            The logger instance for logging messages.
+        calling_ae_title : str, optional
+            The AE title of the calling AE.
+        called_ip : str, optional
+            The IP address of the called AE.
+        called_port : int, optional
+            The port number of the called AE.
+        called_ae_title : str, optional
+            The AE title of the called AE.
+        """
+        super().__init__(
+            logger,
+            calling_ae_title=calling_ae_title,
+            called_ip=called_ip,
+            called_port=called_port,
+            called_ae_title=called_ae_title,
+        )
+        self.logger.debug("UPSPullCFindSCU initialized")
+
+    def _add_requested_context(self):
+        """Adds the Unified Procedure Step Pull SOP Class presentation context."""
+        super()._add_requested_context()
+        self.ae.add_requested_context(UnifiedProcedureStepPull)
+        self.logger.debug(f"UPS Pull Presentation context added: {UnifiedProcedureStepPull}")
+
+    def create_ups_query(
+        self,
+        ups_uid: str = "",
+        machine_name: str = "",
+        procedure_step_state: str = "SCHEDULED",
+        scheduled_no_sooner_than: str = None,
+        scheduled_no_later_than: str = None,
+    ) -> Dataset:
+        """Construct query for the UPS per RO-58, or directly if the UPS UID is already known e.g. via UPS Event
+        Args:
+            ups_uid (str): The SOP Instance UID for the specific Unified Procedure Step. Empty default
+            machine_name (str): The name of the treatment machine as specified in the RT (Ion) Plan.
+                Empty default but should be populated.
+            procedure_step_state (str): SCHEDULED/IN PROGRESS/COMPLETED/CANCELED, "SCHEDULED" default
+            scheduled_no_sooner_than (datetime):  earliest possible matching start datetime. Empty default
+            scheduled_no_later_than (datetime): latest possible matching start datetime. Empty default
+
+        Returns:
+            Dataset: A query dataset requesting the specific UPS instance
+        """
+        # TODO: split into 2 methods, one to check if a specific UPS is still in SCHEDULED state
+        # and one to search for UPS. We could also create this is a TDWIICFindSCU for RO-58 if ever we
+        # would implement other IHE transactions with different requirements. This is why I made it an
+        # instance method and not a @classmethod or @staticmethod method.
+        ds = Dataset()
+        # Request only the UPS with matching UID
+        ds.add(DataElement("SOPInstanceUID", VR.UI, None))
+
+        if ups_uid:  # Really weird, with an empty string ups_uid is said to be bool
+            if len(ups_uid) > 0:
+                ds.SOPInstanceUID = ups_uid
+                # avoid over filtering.  If the UID is known, the caller can determine if the procedure step state
+                # is a value that makes it uninteresting, i.e. if they only wanted it if it was still scheduled.
+                procedure_step_state = ""
+
+        # Request that the patient name and patient id be populated in the response
+        ds.add(DataElement("PatientName", VR.PN, ""))
+        ds.add(DataElement("PatientID", VR.LO, ""))
+
+        # Request only RT Treatments with Internal Verification
+        # Formally, only this kind of work item is allowed in TDW-II,
+        # however, there is also a RT Treatment QA item, so this could be left as an empty sequence
+        # as an extension of TDW-II
+        scheduled_work_item_code_seq = Sequence()
+        # Code Value shall be retrieved with Single Value Matching.
+        # Coding Scheme Designator shall be retrieved with Single Value Matching.
+        # Code Meaning shall not be used as Matching Key
+        scheduled_work_item = create_code_seq_item("121726", "DCM", "")
+        scheduled_work_item_code_seq.append(scheduled_work_item)
+
+        ds.add(DataElement("ScheduledWorkitemCodeSequence", VR.SQ, scheduled_work_item_code_seq))
+
+        # Request that the Input Information Sequence be populated in the response
+        # This is the key information needed by a Performer or a Watcher (Co-Performer)
+        # so it can gather up the reference data for the treatment session
+        ds.add(DataElement("InputInformationSequence", VR.SQ, Sequence()))
+
+        # Request only those UPS that are for the given treatment machine name
+        # For a query that is specific to a unique UPS, an empty value for the machine name means match any
+        # but because it's already a unique UPS, the use or lack of filtering isn't an issue either way.
+        # could use designator of 99IHERO2008 or 99IHERO2018, but leaving that empty to allow match to either
+        # Discussion: For the ScheduledStationNameCodeSequence, the Code Designator is defined by the TMS.
+        # Also removing the Code Meaning which should not be used as matching key
+        scheduled_station_name_item = create_code_seq_item(machine_name, "", "")
+        # R in PS3.4 Table CC.2.5-3
+        ds.add(DataElement("ScheduledStationNameCodeSequence", VR.SQ, Sequence([scheduled_station_name_item])))
+
+        ds.add(DataElement("ProcedureStepState", VR.SH, procedure_step_state))
+
+        ds.add(DataElement("ScheduledProcessingParametersSequence", VR.SQ, Sequence()))
+
+        ds.add(DataElement("WorklistLabel", VR.LO, ""))
+
+        start_datetime_string = ""
+        end_datetime_string = ""
+        if scheduled_no_sooner_than is not None:
+            start_datetime_string = scheduled_no_sooner_than
+        if scheduled_no_later_than is not None:
+            end_datetime_string = scheduled_no_later_than
+
+        if scheduled_no_sooner_than is None and scheduled_no_later_than is None:
+            ds.add(DataElement("ScheduledProcedureStepStartDateTime", VR.DT, ""))
+        else:
+            ds.add(DataElement("ScheduledProcedureStepStartDateTime", VR.DT, f"{start_datetime_string}-{end_datetime_string}"))
+
+        return ds
+
+    def get_ups(self, ds_query: Dataset) -> list[Dataset]:
+        """
+        Perform UPS C-FIND-RQ and return responses that have UPS content.
+
+        Args:
+            ds_query (pydicom.Dataset): query content/request
+
+        Returns:
+            list[Dataset]: List of response datasets with UPS content.
+        """
+        # Establish association with the SCP
+        success, details = self._associate(required_sop_classes=[UnifiedProcedureStepPull])
+
+        if details.status == "Error":
+            self.logger.error(f"Association failed: {details.description}")
+            return []
+
+        if details.status == "Warning":
+            accepted_sop_names = [f"[{UID(uid).name}]" for uid in details.accepted_sop_classes]
+            self.logger.warning(f"{details.description} - Accepted SOP Classes: {', '.join(accepted_sop_names)}")
+
+        ups_responses = []
+        try:
+            # Send the C-FIND request
+            self.logger.debug(f"Sending C-FIND request with Identifier: {ds_query}")
+            responses = self.assoc.send_c_find(ds_query, query_model=UnifiedProcedureStepPull)
+
+            for response in responses:
+                if isinstance(response, tuple):
+                    rsp_status, rsp_dataset = response
+                else:
+                    rsp_status = response
+                    rsp_dataset = None
+                # Handle the response
+                self.logger.debug(f"Response status: {rsp_status}")
+                self.logger.debug(f"Response dataset: {rsp_dataset}")
+
+                result = self._handle_response(rsp_status, rsp_dataset)
+
+                if result.status_category == "Pending":
+                    self.logger.info("Pending response received")
+                    if rsp_dataset is not None:
+                        ups_responses.append(rsp_dataset)
+                    else:
+                        self.logger.error("Pending response contains no Dataset")
+                        break
+                    continue
+                elif result.status_category == "Success":
+                    self.logger.info("C-FIND request successful")
+                elif result.status_category == "Failure":
+                    self.logger.error(f"C-FIND request failed: {result.status_description}")
+                    break
+        finally:
+            self.assoc.release()
+
+        return ups_responses
+
+    def _get_status_description(self, status_code):
+        """
+        Retrieves the description for a specific UPS status code.
+
+        Args:
+            status_code (int): The status code to look up.
+
+        Returns:
+            str: The description of the status code.
+        """
+        from pynetdicom.status import UNIFIED_PROCEDURE_STEP_SERVICE_CLASS_STATUS
+
+        return UNIFIED_PROCEDURE_STEP_SERVICE_CLASS_STATUS.get(status_code, ("Unknown", "Unknown status code"))[1]


### PR DESCRIPTION
This merge request addresses part of issue https://github.com/sjswerdloff/tdwii_plus_examples/issues/85.
It refactors upsfindscu.py from the tdwii_plus_examples/TDWII_PPVS_subscriber folder.
The create_ups_quern and get_ups functions are refactored in the UPSPullCFindSCU in tdwii_plus_examples package folder in upspullcfindscu.py.
UPSPullCFindSCU is derived from a BaseSCU class.
The upsfind.py CLI application in added to the tdwii_plus_examples/cli folder.
Tests are provided.

TDWII_PPVS_subscriber and TDD UI application are refactored to use the UPSPullCFindSCU and the UPSPulNSetSCU Classes.