### PR TITLE
add David Wikler as author

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "tdwii_plus_examples"
-version = "0.2.0"
+version = "0.3.0"
 description = "Working sample code for implementing some tdw-ii transactions and some extensions such as UPSWatch and UPSWEvent based subscriptions for activities of interest in a treatment room"
-authors = ["Stuart Swerdloff <sjswerdloff@gmail.com>"]
+authors = ["Stuart Swerdloff <sjswerdloff@gmail.com>", "David Wikler <dwikler@ulb.be>"]
 license = "Apache 2.0"
 readme = "README.md"
 packages = [{include = "tdwii_plus_examples"}]


### PR DESCRIPTION
bump version to 0.3.0 given that the refactoring has changed the interface (one of the goals of the refactoring)

## Summary by Sourcery

Bump project version to 0.3.0 and add David Wikler as a project author

Build:
- Bump project version to 0.3.0

Documentation:
- Add David Wikler to project authors