### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sjswerdloff @dwikler


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add a CODEOWNERS file to define default code owners for the repository